### PR TITLE
Make the user interface better for selecting core powers

### DIFF
--- a/Standard Crew.cat
+++ b/Standard Crew.cat
@@ -95,7 +95,7 @@
         </selectionEntryGroup>
         <selectionEntryGroup name="Powers" id="8534-c853-b847-fd9f" hidden="false">
           <entryLinks>
-            <entryLink import="true" name="Core Powers" hidden="false" id="2daa-2534-fd41-863b" type="selectionEntryGroup" targetId="8f77-0290-5b40-2a4c">
+            <entryLink import="true" name="Core Powers" hidden="false" id="2daa-2534-fd41-863b" type="selectionEntryGroup" targetId="4da1-d546-eaec-5450">
               <constraints>
                 <constraint type="min" value="2" field="selections" scope="parent" shared="true" id="cee6-9b20-b162-4174"/>
                 <constraint type="max" value="3" field="selections" scope="parent" shared="true" id="43f9-16f6-af44-2d57"/>
@@ -209,7 +209,7 @@
         </selectionEntryGroup>
         <selectionEntryGroup name="Powers" id="8800-795c-6d77-cc09" hidden="false">
           <entryLinks>
-            <entryLink import="true" name="Core Powers" hidden="false" id="9e9b-110a-450e-035f" type="selectionEntryGroup" targetId="8f77-0290-5b40-2a4c">
+            <entryLink import="true" name="Core Powers" hidden="false" id="9e9b-110a-450e-035f" type="selectionEntryGroup" targetId="4da1-d546-eaec-5450">
               <constraints>
                 <constraint type="min" value="3" field="selections" scope="parent" shared="true" id="c200-1c48-4417-9b0b"/>
                 <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="32c3-66d9-86db-9b9e"/>
@@ -346,7 +346,7 @@
         </selectionEntryGroup>
         <selectionEntryGroup name="Powers" id="7ba4-eacc-6f91-3a5c" hidden="false">
           <entryLinks>
-            <entryLink import="true" name="Core Powers" hidden="false" id="67c6-e9db-917e-2403" type="selectionEntryGroup" targetId="8f77-0290-5b40-2a4c">
+            <entryLink import="true" name="Core Powers" hidden="false" id="67c6-e9db-917e-2403" type="selectionEntryGroup" targetId="4da1-d546-eaec-5450">
               <constraints>
                 <constraint type="min" value="3" field="selections" scope="parent" shared="true" id="7f6f-b98f-9c49-5ab4"/>
                 <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="24d7-47ee-7640-9a67"/>
@@ -460,7 +460,7 @@
         </selectionEntryGroup>
         <selectionEntryGroup name="Powers" id="d0c5-2387-3165-1390" hidden="false">
           <entryLinks>
-            <entryLink import="true" name="Core Powers" hidden="false" id="b537-e041-2fe7-3c5e" type="selectionEntryGroup" targetId="8f77-0290-5b40-2a4c">
+            <entryLink import="true" name="Core Powers" hidden="false" id="b537-e041-2fe7-3c5e" type="selectionEntryGroup" targetId="4da1-d546-eaec-5450">
               <constraints>
                 <constraint type="min" value="3" field="selections" scope="parent" shared="true" id="59d4-0763-5692-2119"/>
                 <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="12fc-7f9f-c24e-2572"/>
@@ -597,7 +597,7 @@
         </selectionEntryGroup>
         <selectionEntryGroup name="Powers" id="a303-ac52-55a9-4055" hidden="false">
           <entryLinks>
-            <entryLink import="true" name="Core Powers" hidden="false" id="5cd3-85df-e54d-52ea" type="selectionEntryGroup" targetId="8f77-0290-5b40-2a4c">
+            <entryLink import="true" name="Core Powers" hidden="false" id="5cd3-85df-e54d-52ea" type="selectionEntryGroup" targetId="4da1-d546-eaec-5450">
               <constraints>
                 <constraint type="min" value="3" field="selections" scope="parent" shared="true" id="ff87-25af-8baa-224a"/>
                 <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="b05f-9649-2bbe-de73"/>
@@ -720,7 +720,7 @@
         </selectionEntryGroup>
         <selectionEntryGroup name="Powers" id="c129-a340-f6b7-eb94" hidden="false">
           <entryLinks>
-            <entryLink import="true" name="Core Powers" hidden="false" id="a176-a5ae-2947-b59b" type="selectionEntryGroup" targetId="8f77-0290-5b40-2a4c">
+            <entryLink import="true" name="Core Powers" hidden="false" id="a176-a5ae-2947-b59b" type="selectionEntryGroup" targetId="4da1-d546-eaec-5450">
               <constraints>
                 <constraint type="min" value="3" field="selections" scope="parent" shared="true" id="59ef-5486-a375-bb43"/>
                 <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="cf9d-619f-1971-30ac"/>
@@ -843,7 +843,7 @@
         </selectionEntryGroup>
         <selectionEntryGroup name="Powers" id="ce2f-5ed0-b359-26d3" hidden="false">
           <entryLinks>
-            <entryLink import="true" name="Core Powers" hidden="false" id="3202-65ee-1f18-9a6b" type="selectionEntryGroup" targetId="8f77-0290-5b40-2a4c">
+            <entryLink import="true" name="Core Powers" hidden="false" id="3202-65ee-1f18-9a6b" type="selectionEntryGroup" targetId="4da1-d546-eaec-5450">
               <constraints>
                 <constraint type="min" value="3" field="selections" scope="parent" shared="true" id="ab9c-4487-9be5-f5df"/>
                 <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="cff2-c051-4580-1fec"/>
@@ -966,7 +966,7 @@
         </selectionEntryGroup>
         <selectionEntryGroup name="Powers" id="3e07-7045-a9b4-7267" hidden="false">
           <entryLinks>
-            <entryLink import="true" name="Core Powers" hidden="false" id="7765-a7b7-83a8-eede" type="selectionEntryGroup" targetId="8f77-0290-5b40-2a4c">
+            <entryLink import="true" name="Core Powers" hidden="false" id="7765-a7b7-83a8-eede" type="selectionEntryGroup" targetId="4da1-d546-eaec-5450">
               <constraints>
                 <constraint type="min" value="2" field="selections" scope="parent" shared="true" id="4bde-30a7-0600-8508"/>
                 <constraint type="max" value="3" field="selections" scope="parent" shared="true" id="3e24-b971-3150-2572"/>
@@ -1080,7 +1080,7 @@
         </selectionEntryGroup>
         <selectionEntryGroup name="Powers" id="5eb2-ce66-bce5-4fef" hidden="false">
           <entryLinks>
-            <entryLink import="true" name="Core Powers" hidden="false" id="589d-f86d-50fb-286a" type="selectionEntryGroup" targetId="8f77-0290-5b40-2a4c">
+            <entryLink import="true" name="Core Powers" hidden="false" id="589d-f86d-50fb-286a" type="selectionEntryGroup" targetId="4da1-d546-eaec-5450">
               <constraints>
                 <constraint type="min" value="3" field="selections" scope="parent" shared="true" id="5497-86b2-1756-f617"/>
                 <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="8b64-7221-f4c7-59ca"/>
@@ -1203,7 +1203,7 @@
         </selectionEntryGroup>
         <selectionEntryGroup name="Powers" id="45dc-7913-62e7-bbdb" hidden="false">
           <entryLinks>
-            <entryLink import="true" name="Core Powers" hidden="false" id="6f24-50d3-f9f8-d05a" type="selectionEntryGroup" targetId="8f77-0290-5b40-2a4c">
+            <entryLink import="true" name="Core Powers" hidden="false" id="6f24-50d3-f9f8-d05a" type="selectionEntryGroup" targetId="4da1-d546-eaec-5450">
               <constraints>
                 <constraint type="min" value="3" field="selections" scope="parent" shared="true" id="4185-dacf-63dc-2344"/>
                 <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="069a-674b-13a2-60a8"/>
@@ -1317,7 +1317,7 @@
         </selectionEntryGroup>
         <selectionEntryGroup name="Powers" id="7be6-cb37-fb0e-280a" hidden="false">
           <entryLinks>
-            <entryLink import="true" name="Core Powers" hidden="false" id="90cd-65d7-74b4-c0e6" type="selectionEntryGroup" targetId="8f77-0290-5b40-2a4c">
+            <entryLink import="true" name="Core Powers" hidden="false" id="90cd-65d7-74b4-c0e6" type="selectionEntryGroup" targetId="4da1-d546-eaec-5450">
               <constraints>
                 <constraint type="min" value="2" field="selections" scope="parent" shared="true" id="c700-364a-11f4-4c8c"/>
                 <constraint type="max" value="3" field="selections" scope="parent" shared="true" id="6ff1-fb4b-fa57-ce6e"/>
@@ -1431,7 +1431,7 @@
         </selectionEntryGroup>
         <selectionEntryGroup name="Powers" id="3cb1-82ec-35b7-6689" hidden="false">
           <entryLinks>
-            <entryLink import="true" name="Core Powers" hidden="false" id="3f47-8fe7-2bea-2399" type="selectionEntryGroup" targetId="8f77-0290-5b40-2a4c">
+            <entryLink import="true" name="Core Powers" hidden="false" id="3f47-8fe7-2bea-2399" type="selectionEntryGroup" targetId="4da1-d546-eaec-5450">
               <constraints>
                 <constraint type="min" value="2" field="selections" scope="parent" shared="true" id="e02f-dece-e73e-f35e"/>
                 <constraint type="max" value="3" field="selections" scope="parent" shared="true" id="574b-7168-a417-ba5d"/>
@@ -1568,7 +1568,7 @@
         </selectionEntryGroup>
         <selectionEntryGroup name="Powers" id="f2b4-0bd5-1443-3cd9" hidden="false">
           <entryLinks>
-            <entryLink import="true" name="Core Powers" hidden="false" id="5264-f199-5c24-b51f" type="selectionEntryGroup" targetId="8f77-0290-5b40-2a4c">
+            <entryLink import="true" name="Core Powers" hidden="false" id="5264-f199-5c24-b51f" type="selectionEntryGroup" targetId="4da1-d546-eaec-5450">
               <constraints>
                 <constraint type="min" value="2" field="selections" scope="parent" shared="true" id="8303-8b4f-7346-129b"/>
                 <constraint type="max" value="3" field="selections" scope="parent" shared="true" id="d846-5de1-e004-b09b"/>
@@ -1691,7 +1691,7 @@
         </selectionEntryGroup>
         <selectionEntryGroup name="Powers" id="fef8-0834-8140-2969" hidden="false">
           <entryLinks>
-            <entryLink import="true" name="Core Powers" hidden="false" id="ade9-5511-c784-2d49" type="selectionEntryGroup" targetId="8f77-0290-5b40-2a4c">
+            <entryLink import="true" name="Core Powers" hidden="false" id="ade9-5511-c784-2d49" type="selectionEntryGroup" targetId="4da1-d546-eaec-5450">
               <constraints>
                 <constraint type="min" value="2" field="selections" scope="parent" shared="true" id="2929-ee04-1a4b-4ef1"/>
                 <constraint type="max" value="3" field="selections" scope="parent" shared="true" id="d578-968a-2baa-a77d"/>
@@ -1828,7 +1828,7 @@
         </selectionEntryGroup>
         <selectionEntryGroup name="Powers" id="13f2-8008-1a4d-667c" hidden="false">
           <entryLinks>
-            <entryLink import="true" name="Core Powers" hidden="false" id="de89-38b6-638e-3bc4" type="selectionEntryGroup" targetId="8f77-0290-5b40-2a4c">
+            <entryLink import="true" name="Core Powers" hidden="false" id="de89-38b6-638e-3bc4" type="selectionEntryGroup" targetId="4da1-d546-eaec-5450">
               <constraints>
                 <constraint type="min" value="2" field="selections" scope="parent" shared="true" id="64d1-79b1-8e2c-3549"/>
                 <constraint type="max" value="3" field="selections" scope="parent" shared="true" id="8a34-db5c-a7d2-7576"/>
@@ -1942,7 +1942,7 @@
         </selectionEntryGroup>
         <selectionEntryGroup name="Powers" id="80c2-b44e-cc7b-c78b" hidden="false">
           <entryLinks>
-            <entryLink import="true" name="Core Powers" hidden="false" id="2113-06aa-6617-aa22" type="selectionEntryGroup" targetId="8f77-0290-5b40-2a4c">
+            <entryLink import="true" name="Core Powers" hidden="false" id="2113-06aa-6617-aa22" type="selectionEntryGroup" targetId="4da1-d546-eaec-5450">
               <constraints>
                 <constraint type="min" value="2" field="selections" scope="parent" shared="true" id="f2ee-f16c-b0aa-b41c"/>
                 <constraint type="max" value="3" field="selections" scope="parent" shared="true" id="122d-76df-284d-2863"/>
@@ -2067,7 +2067,7 @@
         </selectionEntryGroup>
         <selectionEntryGroup name="Powers" id="7b84-75d8-ccce-c143" hidden="false">
           <entryLinks>
-            <entryLink import="true" name="Core Powers" hidden="false" id="605f-d87c-3819-f7e2" type="selectionEntryGroup" targetId="8f77-0290-5b40-2a4c">
+            <entryLink import="true" name="Core Powers" hidden="false" id="605f-d87c-3819-f7e2" type="selectionEntryGroup" targetId="4da1-d546-eaec-5450">
               <constraints>
                 <constraint type="min" value="3" field="selections" scope="parent" shared="true" id="ca95-8f13-03cb-b165"/>
                 <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="6119-227e-155f-af8d"/>
@@ -2181,7 +2181,7 @@
         </selectionEntryGroup>
         <selectionEntryGroup name="Powers" id="1796-b9fb-61ba-c47a" hidden="false">
           <entryLinks>
-            <entryLink import="true" name="Core Powers" hidden="false" id="2aba-7a7d-702d-4477" type="selectionEntryGroup" targetId="8f77-0290-5b40-2a4c">
+            <entryLink import="true" name="Core Powers" hidden="false" id="2aba-7a7d-702d-4477" type="selectionEntryGroup" targetId="4da1-d546-eaec-5450">
               <constraints>
                 <constraint type="min" value="3" field="selections" scope="parent" shared="true" id="d30c-19b0-8433-6fde"/>
                 <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="ab25-d4bb-5d85-3d51"/>
@@ -2306,7 +2306,7 @@
         </selectionEntryGroup>
         <selectionEntryGroup name="Powers" id="507c-9712-2da5-07f4" hidden="false">
           <entryLinks>
-            <entryLink import="true" name="Core Powers" hidden="false" id="bc68-b642-1164-6d53" type="selectionEntryGroup" targetId="8f77-0290-5b40-2a4c">
+            <entryLink import="true" name="Core Powers" hidden="false" id="bc68-b642-1164-6d53" type="selectionEntryGroup" targetId="4da1-d546-eaec-5450">
               <constraints>
                 <constraint type="min" value="2" field="selections" scope="parent" shared="true" id="36a3-fc76-bec3-c948"/>
                 <constraint type="max" value="3" field="selections" scope="parent" shared="true" id="6060-13e5-22d6-24c7"/>
@@ -2420,7 +2420,7 @@
         </selectionEntryGroup>
         <selectionEntryGroup name="Powers" id="a184-bf55-7cbc-48b2" hidden="false">
           <entryLinks>
-            <entryLink import="true" name="Core Powers" hidden="false" id="81d8-01ed-7ad8-a892" type="selectionEntryGroup" targetId="8f77-0290-5b40-2a4c">
+            <entryLink import="true" name="Core Powers" hidden="false" id="81d8-01ed-7ad8-a892" type="selectionEntryGroup" targetId="4da1-d546-eaec-5450">
               <constraints>
                 <constraint type="min" value="2" field="selections" scope="parent" shared="true" id="2ea5-58f5-741a-56b4"/>
                 <constraint type="max" value="3" field="selections" scope="parent" shared="true" id="d954-e55a-953c-08d5"/>

--- a/Standard Crew.cat
+++ b/Standard Crew.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="1adb-b357-2db9-e646" name="Standard Crew" revision="25" battleScribeVersion="2.03" library="false" gameSystemId="b7a1-a7ef-bd2f-c484" gameSystemRevision="36" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="1adb-b357-2db9-e646" name="Standard Crew" revision="26" battleScribeVersion="2.03" library="false" gameSystemId="b7a1-a7ef-bd2f-c484" gameSystemRevision="36" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <selectionEntries>
     <selectionEntry id="e7fc-369a-1059-31e1" name="First Mate Biomorph" hidden="false" collective="false" import="true" type="model">
       <profiles>
@@ -7,34 +7,34 @@
           <modifiers>
             <modifier type="increment" field="dc65-e78a-d390-d9d5" value="1">
               <conditions>
-                <condition field="selections" scope="e7fc-369a-1059-31e1" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bd04-29f1-86fb-7d68" type="notEqualTo"/>
+                <condition field="selections" scope="e7fc-369a-1059-31e1" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bd04-29f1-86fb-7d68" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="453a-8ce6-f448-bb37" value="+3">
               <conditions>
-                <condition field="selections" scope="e7fc-369a-1059-31e1" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="54d1-3c5f-8e6d-61a8" type="notEqualTo"/>
+                <condition field="selections" scope="e7fc-369a-1059-31e1" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="54d1-3c5f-8e6d-61a8" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="d603-9472-1d68-663e" value="+3">
               <conditions>
-                <condition field="selections" scope="e7fc-369a-1059-31e1" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e902-9a47-9cb1-b0ef" type="notEqualTo"/>
+                <condition field="selections" scope="e7fc-369a-1059-31e1" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e902-9a47-9cb1-b0ef" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="1">
               <conditions>
-                <condition field="selections" scope="e7fc-369a-1059-31e1" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c5f-174f-fa1f-26c7" type="greaterThan"/>
+                <condition field="selections" scope="e7fc-369a-1059-31e1" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c5f-174f-fa1f-26c7" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="4">
               <conditions>
-                <condition field="selections" scope="e7fc-369a-1059-31e1" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea4f-6372-4af1-e30b" type="greaterThan"/>
+                <condition field="selections" scope="e7fc-369a-1059-31e1" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea4f-6372-4af1-e30b" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <modifierGroups>
             <modifierGroup>
               <conditions>
-                <condition field="selections" scope="e7fc-369a-1059-31e1" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b824-fc04-4c55-b49e" type="greaterThan"/>
+                <condition field="selections" scope="e7fc-369a-1059-31e1" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b824-fc04-4c55-b49e" type="greaterThan"/>
               </conditions>
               <modifiers>
                 <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="2"/>
@@ -60,59 +60,68 @@
       <selectionEntryGroups>
         <selectionEntryGroup id="7a5e-f557-3a97-3a3e" name="Background" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03fb-7fb5-fd93-d363" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e6b-8a06-9dd3-5a52" type="max"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03fb-7fb5-fd93-d363" type="min"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e6b-8a06-9dd3-5a52" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="bd04-29f1-86fb-7d68" name="+1 Move" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e6a2-9bc0-c9f2-f278" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e6a2-9bc0-c9f2-f278" type="max"/>
               </constraints>
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="54d1-3c5f-8e6d-61a8" name="+1 Fight" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="75b3-1c29-94b7-bf3b" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="75b3-1c29-94b7-bf3b" type="max"/>
               </constraints>
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e902-9a47-9cb1-b0ef" name="+1 Shoot" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec11-5af1-9876-fb74" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec11-5af1-9876-fb74" type="max"/>
               </constraints>
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="6a75-4cb3-f5b4-3c0e" name="Powers" hidden="false" collective="false" import="true" targetId="7753-4141-f613-ae54" type="selectionEntryGroup">
+        <selectionEntryGroup name="Powers" id="8534-c853-b847-fd9f" hidden="false">
+          <entryLinks>
+            <entryLink import="true" name="Core Powers" hidden="false" id="2daa-2534-fd41-863b" type="selectionEntryGroup" targetId="8f77-0290-5b40-2a4c">
+              <constraints>
+                <constraint type="min" value="2" field="selections" scope="parent" shared="true" id="cee6-9b20-b162-4174"/>
+                <constraint type="max" value="3" field="selections" scope="parent" shared="true" id="43f9-16f6-af44-2d57"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Other Powers" hidden="false" id="809a-3e64-427e-8f51" type="selectionEntryGroup" targetId="d187-4aa6-4f21-7b77"/>
+          </entryLinks>
           <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8479-04ef-c0c9-1afa" type="max"/>
+            <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="67b1-03ad-bd0d-7b50"/>
           </constraints>
           <infoLinks>
-            <infoLink id="c6ef-b0a3-2084-36a4" name="Power Activation (First Mate)" hidden="false" targetId="6819-fdeb-c82b-4b42" type="rule"/>
+            <infoLink name="Power Activation (First Mate)" id="02ff-110c-1daa-0d4f" hidden="false" type="rule" targetId="6819-fdeb-c82b-4b42"/>
           </infoLinks>
-        </entryLink>
-        <entryLink id="fb9d-577c-7212-7dbe" name="Gears" hidden="false" collective="false" import="true" targetId="270a-a5c0-3695-1fe4" type="selectionEntryGroup">
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="fb9d-577c-7212-7dbe" name="Equipment" hidden="false" collective="false" import="true" targetId="270a-a5c0-3695-1fe4" type="selectionEntryGroup">
           <constraints>
-            <constraint field="ef24-ff59-caa4-b0e8" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bf99-1689-5758-d46c" type="max"/>
+            <constraint field="ef24-ff59-caa4-b0e8" scope="parent" value="5" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bf99-1689-5758-d46c" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="f530-504a-ca0a-2f64" name="Level" hidden="false" collective="false" import="true" targetId="4cd1-ff48-5eaf-e868" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4441-f05c-6eb0-22da" name="Veteran" hidden="false" collective="false" import="true" type="model">
@@ -121,34 +130,34 @@
           <modifiers>
             <modifier type="set" field="d603-9472-1d68-663e" value="+3">
               <conditions>
-                <condition field="selections" scope="4441-f05c-6eb0-22da" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f48-0f41-257b-f8e9" type="notEqualTo"/>
+                <condition field="selections" scope="4441-f05c-6eb0-22da" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f48-0f41-257b-f8e9" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="453a-8ce6-f448-bb37" value="+5">
               <conditions>
-                <condition field="selections" scope="4441-f05c-6eb0-22da" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5853-69a5-4263-2ab0" type="notEqualTo"/>
+                <condition field="selections" scope="4441-f05c-6eb0-22da" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5853-69a5-4263-2ab0" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="dc65-e78a-d390-d9d5" value="1">
               <conditions>
-                <condition field="selections" scope="4441-f05c-6eb0-22da" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4111-be6e-185e-4c7f" type="notEqualTo"/>
+                <condition field="selections" scope="4441-f05c-6eb0-22da" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4111-be6e-185e-4c7f" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="1">
               <conditions>
-                <condition field="selections" scope="4441-f05c-6eb0-22da" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c5f-174f-fa1f-26c7" type="greaterThan"/>
+                <condition field="selections" scope="4441-f05c-6eb0-22da" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c5f-174f-fa1f-26c7" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="4">
               <conditions>
-                <condition field="selections" scope="4441-f05c-6eb0-22da" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea4f-6372-4af1-e30b" type="greaterThan"/>
+                <condition field="selections" scope="4441-f05c-6eb0-22da" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea4f-6372-4af1-e30b" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <modifierGroups>
             <modifierGroup>
               <conditions>
-                <condition field="selections" scope="4441-f05c-6eb0-22da" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b824-fc04-4c55-b49e" type="greaterThan"/>
+                <condition field="selections" scope="4441-f05c-6eb0-22da" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b824-fc04-4c55-b49e" type="greaterThan"/>
               </conditions>
               <modifiers>
                 <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="2"/>
@@ -167,57 +176,66 @@
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="8ff2-30aa-43bc-cb09" name="New CategoryLink" hidden="false" targetId="16bf-5402-ac6a-dab3" primary="true"/>
+        <categoryLink id="8ff2-30aa-43bc-cb09" name="Captain" hidden="false" targetId="16bf-5402-ac6a-dab3" primary="true"/>
         <categoryLink id="2874-379c-edd6-be27" name="Faction: Stargrave Crew" hidden="false" targetId="7011-8c8a-78f8-283e" primary="false"/>
         <categoryLink id="ed84-e859-9033-cb52" name="Core Veteran" hidden="false" targetId="1510-fec4-0334-8026" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="ae3c-8685-84ee-a21f" name="Background" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a29-6b65-0473-533b" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4009-e306-9e28-989e" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a29-6b65-0473-533b" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4009-e306-9e28-989e" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="4111-be6e-185e-4c7f" name="+1 Move" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5853-69a5-4263-2ab0" name="+1 Fight" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8f48-0f41-257b-f8e9" name="+1 Shoot" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="b7e3-6bda-ceff-29e3" name="Powers" hidden="false" collective="false" import="true" targetId="7753-4141-f613-ae54" type="selectionEntryGroup">
+        <selectionEntryGroup name="Powers" id="8800-795c-6d77-cc09" hidden="false">
+          <entryLinks>
+            <entryLink import="true" name="Core Powers" hidden="false" id="9e9b-110a-450e-035f" type="selectionEntryGroup" targetId="8f77-0290-5b40-2a4c">
+              <constraints>
+                <constraint type="min" value="3" field="selections" scope="parent" shared="true" id="c200-1c48-4417-9b0b"/>
+                <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="32c3-66d9-86db-9b9e"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Other Powers" hidden="false" id="d12f-f89b-14cd-44ea" type="selectionEntryGroup" targetId="d187-4aa6-4f21-7b77"/>
+          </entryLinks>
           <constraints>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2386-dffe-0b3d-ffdb" type="max"/>
+            <constraint type="max" value="5" field="selections" scope="parent" shared="true" id="a58b-ea91-9448-aefb"/>
           </constraints>
           <infoLinks>
-            <infoLink id="12df-db81-9278-7ee9" name="Power Activation (Captain)" hidden="false" targetId="b036-a7e7-db3f-d23b" type="rule"/>
+            <infoLink name="Power Activation (Captain)" id="f4d9-abda-9178-376a" hidden="false" type="rule" targetId="b036-a7e7-db3f-d23b"/>
           </infoLinks>
-        </entryLink>
-        <entryLink id="91ff-2eb5-6dfd-1da8" name="Gears" hidden="false" collective="false" import="true" targetId="270a-a5c0-3695-1fe4" type="selectionEntryGroup">
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="91ff-2eb5-6dfd-1da8" name="Equipment" hidden="false" collective="false" import="true" targetId="270a-a5c0-3695-1fe4" type="selectionEntryGroup">
           <constraints>
-            <constraint field="ef24-ff59-caa4-b0e8" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="eb06-eb3b-8c17-e34e" type="max"/>
+            <constraint field="ef24-ff59-caa4-b0e8" scope="parent" value="6" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="eb06-eb3b-8c17-e34e" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="883d-b85e-69aa-131a" name="Level" hidden="false" collective="false" import="true" targetId="4cd1-ff48-5eaf-e868" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="fc64-9d1d-1a02-4051" name="Tekker" hidden="false" collective="false" import="true" type="model">
@@ -226,39 +244,39 @@
           <modifiers>
             <modifier type="increment" field="c25e-02c0-2580-ff3c" value="1">
               <conditions>
-                <condition field="selections" scope="fc64-9d1d-1a02-4051" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="709e-fe9b-05d8-f238" type="notEqualTo"/>
+                <condition field="selections" scope="fc64-9d1d-1a02-4051" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="709e-fe9b-05d8-f238" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="d603-9472-1d68-663e" value="+3">
               <conditions>
-                <condition field="selections" scope="fc64-9d1d-1a02-4051" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1501-9652-2282-05b9" type="notEqualTo"/>
+                <condition field="selections" scope="fc64-9d1d-1a02-4051" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1501-9652-2282-05b9" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="dc65-e78a-d390-d9d5" value="1">
               <conditions>
-                <condition field="selections" scope="fc64-9d1d-1a02-4051" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fbc-eb6b-6b43-1f27" type="notEqualTo"/>
+                <condition field="selections" scope="fc64-9d1d-1a02-4051" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fbc-eb6b-6b43-1f27" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="453a-8ce6-f448-bb37" value="+4">
               <conditions>
-                <condition field="selections" scope="fc64-9d1d-1a02-4051" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e09e-fe6f-424b-8750" type="notEqualTo"/>
+                <condition field="selections" scope="fc64-9d1d-1a02-4051" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e09e-fe6f-424b-8750" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="1">
               <conditions>
-                <condition field="selections" scope="fc64-9d1d-1a02-4051" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c5f-174f-fa1f-26c7" type="greaterThan"/>
+                <condition field="selections" scope="fc64-9d1d-1a02-4051" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c5f-174f-fa1f-26c7" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="4">
               <conditions>
-                <condition field="selections" scope="fc64-9d1d-1a02-4051" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea4f-6372-4af1-e30b" type="greaterThan"/>
+                <condition field="selections" scope="fc64-9d1d-1a02-4051" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea4f-6372-4af1-e30b" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <modifierGroups>
             <modifierGroup>
               <conditions>
-                <condition field="selections" scope="fc64-9d1d-1a02-4051" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b824-fc04-4c55-b49e" type="greaterThan"/>
+                <condition field="selections" scope="fc64-9d1d-1a02-4051" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b824-fc04-4c55-b49e" type="greaterThan"/>
               </conditions>
               <modifiers>
                 <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="2"/>
@@ -277,75 +295,84 @@
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="35c6-2cd7-f948-2500" name="New CategoryLink" hidden="false" targetId="16bf-5402-ac6a-dab3" primary="true"/>
+        <categoryLink id="35c6-2cd7-f948-2500" name="Captain" hidden="false" targetId="16bf-5402-ac6a-dab3" primary="true"/>
         <categoryLink id="dec7-f1f9-9467-dda4" name="Faction: Stargrave Crew" hidden="false" targetId="7011-8c8a-78f8-283e" primary="false"/>
         <categoryLink id="4ad3-f807-029a-c028" name="Core Tekker" hidden="false" targetId="8702-3db8-4e88-faf8" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="9068-16c6-8c81-5313" name="Background" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="171f-3425-facd-e8b2" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="70cf-302d-5453-56ca" type="max"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="171f-3425-facd-e8b2" type="min"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="70cf-302d-5453-56ca" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="6fbc-eb6b-6b43-1f27" name="+1 Move" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="33b0-8f4e-eb2c-70fa" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="33b0-8f4e-eb2c-70fa" type="max"/>
               </constraints>
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e09e-fe6f-424b-8750" name="+1 Fight" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="abe6-7a6d-bb2a-12f9" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="abe6-7a6d-bb2a-12f9" type="max"/>
               </constraints>
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1501-9652-2282-05b9" name="+1 Shoot" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="62bd-5499-0616-a90c" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="62bd-5499-0616-a90c" type="max"/>
               </constraints>
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="709e-fe9b-05d8-f238" name="+1 Health" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5dac-8722-f814-e1bc" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5dac-8722-f814-e1bc" type="max"/>
               </constraints>
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="673d-b0ce-d11a-2e7f" name="Powers" hidden="false" collective="false" import="true" targetId="7753-4141-f613-ae54" type="selectionEntryGroup">
+        <selectionEntryGroup name="Powers" id="7ba4-eacc-6f91-3a5c" hidden="false">
+          <entryLinks>
+            <entryLink import="true" name="Core Powers" hidden="false" id="67c6-e9db-917e-2403" type="selectionEntryGroup" targetId="8f77-0290-5b40-2a4c">
+              <constraints>
+                <constraint type="min" value="3" field="selections" scope="parent" shared="true" id="7f6f-b98f-9c49-5ab4"/>
+                <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="24d7-47ee-7640-9a67"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Other Powers" hidden="false" id="d6f7-d730-8aab-065c" type="selectionEntryGroup" targetId="d187-4aa6-4f21-7b77"/>
+          </entryLinks>
           <constraints>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="670f-ad54-f41e-1de8" type="max"/>
+            <constraint type="max" value="5" field="selections" scope="parent" shared="true" id="e59a-eed6-f78b-54a2"/>
           </constraints>
           <infoLinks>
-            <infoLink id="5fcc-c841-8752-bfdf" name="Power Activation (Captain)" hidden="false" targetId="b036-a7e7-db3f-d23b" type="rule"/>
+            <infoLink name="Power Activation (Captain)" id="234b-53c8-a0a9-1a90" hidden="false" type="rule" targetId="b036-a7e7-db3f-d23b"/>
           </infoLinks>
-        </entryLink>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
         <entryLink id="4ff0-c21d-cef5-1792" name="Equipment" hidden="false" collective="false" import="true" targetId="270a-a5c0-3695-1fe4" type="selectionEntryGroup">
           <constraints>
-            <constraint field="ef24-ff59-caa4-b0e8" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="81fc-96be-8d62-b641" type="max"/>
+            <constraint field="ef24-ff59-caa4-b0e8" scope="parent" value="6" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="81fc-96be-8d62-b641" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="3e7b-9158-a182-0eb0" name="Level" hidden="false" collective="false" import="true" targetId="4cd1-ff48-5eaf-e868" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="35b5-2789-88be-ffd1" name="Psionicist" hidden="false" collective="false" import="true" type="model">
@@ -354,34 +381,34 @@
           <modifiers>
             <modifier type="increment" field="dc65-e78a-d390-d9d5" value="1">
               <conditions>
-                <condition field="selections" scope="35b5-2789-88be-ffd1" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="af2c-c120-b6fd-ab2b" type="notEqualTo"/>
+                <condition field="selections" scope="35b5-2789-88be-ffd1" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="af2c-c120-b6fd-ab2b" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="d603-9472-1d68-663e" value="+3">
               <conditions>
-                <condition field="selections" scope="35b5-2789-88be-ffd1" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d8f4-0c56-aa60-06c4" type="notEqualTo"/>
+                <condition field="selections" scope="35b5-2789-88be-ffd1" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d8f4-0c56-aa60-06c4" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="453a-8ce6-f448-bb37" value="+4">
               <conditions>
-                <condition field="selections" scope="35b5-2789-88be-ffd1" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="193b-e638-1b37-a9db" type="notEqualTo"/>
+                <condition field="selections" scope="35b5-2789-88be-ffd1" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="193b-e638-1b37-a9db" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="1">
               <conditions>
-                <condition field="selections" scope="35b5-2789-88be-ffd1" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c5f-174f-fa1f-26c7" type="greaterThan"/>
+                <condition field="selections" scope="35b5-2789-88be-ffd1" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c5f-174f-fa1f-26c7" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="4">
               <conditions>
-                <condition field="selections" scope="35b5-2789-88be-ffd1" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea4f-6372-4af1-e30b" type="greaterThan"/>
+                <condition field="selections" scope="35b5-2789-88be-ffd1" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea4f-6372-4af1-e30b" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <modifierGroups>
             <modifierGroup>
               <conditions>
-                <condition field="selections" scope="35b5-2789-88be-ffd1" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b824-fc04-4c55-b49e" type="greaterThan"/>
+                <condition field="selections" scope="35b5-2789-88be-ffd1" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b824-fc04-4c55-b49e" type="greaterThan"/>
               </conditions>
               <modifiers>
                 <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="2"/>
@@ -400,57 +427,66 @@
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="4ef0-6230-5e45-3a57" name="New CategoryLink" hidden="false" targetId="16bf-5402-ac6a-dab3" primary="true"/>
+        <categoryLink id="4ef0-6230-5e45-3a57" name="Captain" hidden="false" targetId="16bf-5402-ac6a-dab3" primary="true"/>
         <categoryLink id="5b45-0540-21c9-5030" name="Faction: Stargrave Crew" hidden="false" targetId="7011-8c8a-78f8-283e" primary="false"/>
         <categoryLink id="19f9-568e-873c-fe20" name="Core Psionicist" hidden="false" targetId="9e36-ac96-3132-f141" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="0feb-779f-8aac-74e6" name="Background" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1561-0152-043d-5c5d" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="96d2-fa93-88ea-3d90" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1561-0152-043d-5c5d" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="96d2-fa93-88ea-3d90" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="af2c-c120-b6fd-ab2b" name="+1 Move" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="193b-e638-1b37-a9db" name="+1 Fight" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d8f4-0c56-aa60-06c4" name="+1 Shoot" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="b76a-c45a-3e94-6d64" name="Powers" hidden="false" collective="false" import="true" targetId="7753-4141-f613-ae54" type="selectionEntryGroup">
+        <selectionEntryGroup name="Powers" id="d0c5-2387-3165-1390" hidden="false">
+          <entryLinks>
+            <entryLink import="true" name="Core Powers" hidden="false" id="b537-e041-2fe7-3c5e" type="selectionEntryGroup" targetId="8f77-0290-5b40-2a4c">
+              <constraints>
+                <constraint type="min" value="3" field="selections" scope="parent" shared="true" id="59d4-0763-5692-2119"/>
+                <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="12fc-7f9f-c24e-2572"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Other Powers" hidden="false" id="2b9a-63c1-5394-2f4b" type="selectionEntryGroup" targetId="d187-4aa6-4f21-7b77"/>
+          </entryLinks>
           <constraints>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5302-75ef-bb90-ea2d" type="max"/>
+            <constraint type="max" value="5" field="selections" scope="parent" shared="true" id="efe6-11a5-fb5e-5a61"/>
           </constraints>
           <infoLinks>
-            <infoLink id="5eb4-1743-2dd7-e1ab" name="Power Activation (Captain)" hidden="false" targetId="b036-a7e7-db3f-d23b" type="rule"/>
+            <infoLink name="Power Activation (Captain)" id="aaba-815f-6135-751d" hidden="false" type="rule" targetId="b036-a7e7-db3f-d23b"/>
           </infoLinks>
-        </entryLink>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
         <entryLink id="15f2-ef29-c1b2-1a11" name="Equipment" hidden="false" collective="false" import="true" targetId="270a-a5c0-3695-1fe4" type="selectionEntryGroup">
           <constraints>
-            <constraint field="ef24-ff59-caa4-b0e8" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4d23-5af5-1887-f5f8" type="max"/>
+            <constraint field="ef24-ff59-caa4-b0e8" scope="parent" value="6" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4d23-5af5-1887-f5f8" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="5475-8bd2-752e-093d" name="Level" hidden="false" collective="false" import="true" targetId="4cd1-ff48-5eaf-e868" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7e2b-7422-9372-bcc3" name="Robotics Expert" hidden="false" collective="false" import="true" type="model">
@@ -459,39 +495,39 @@
           <modifiers>
             <modifier type="increment" field="c25e-02c0-2580-ff3c" value="1">
               <conditions>
-                <condition field="selections" scope="7e2b-7422-9372-bcc3" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="77c7-0bd2-1f34-e91e" type="notEqualTo"/>
+                <condition field="selections" scope="7e2b-7422-9372-bcc3" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="77c7-0bd2-1f34-e91e" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="dc65-e78a-d390-d9d5" value="1">
               <conditions>
-                <condition field="selections" scope="7e2b-7422-9372-bcc3" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="503d-f90c-3668-34c7" type="notEqualTo"/>
+                <condition field="selections" scope="7e2b-7422-9372-bcc3" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="503d-f90c-3668-34c7" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="453a-8ce6-f448-bb37" value="+4">
               <conditions>
-                <condition field="selections" scope="7e2b-7422-9372-bcc3" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b9d8-51e5-8551-87f6" type="notEqualTo"/>
+                <condition field="selections" scope="7e2b-7422-9372-bcc3" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b9d8-51e5-8551-87f6" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="d603-9472-1d68-663e" value="+3">
               <conditions>
-                <condition field="selections" scope="7e2b-7422-9372-bcc3" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c206-f02f-3526-f5e2" type="notEqualTo"/>
+                <condition field="selections" scope="7e2b-7422-9372-bcc3" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c206-f02f-3526-f5e2" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="1">
               <conditions>
-                <condition field="selections" scope="7e2b-7422-9372-bcc3" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c5f-174f-fa1f-26c7" type="greaterThan"/>
+                <condition field="selections" scope="7e2b-7422-9372-bcc3" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c5f-174f-fa1f-26c7" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="4">
               <conditions>
-                <condition field="selections" scope="7e2b-7422-9372-bcc3" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea4f-6372-4af1-e30b" type="greaterThan"/>
+                <condition field="selections" scope="7e2b-7422-9372-bcc3" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea4f-6372-4af1-e30b" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <modifierGroups>
             <modifierGroup>
               <conditions>
-                <condition field="selections" scope="7e2b-7422-9372-bcc3" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b824-fc04-4c55-b49e" type="greaterThan"/>
+                <condition field="selections" scope="7e2b-7422-9372-bcc3" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b824-fc04-4c55-b49e" type="greaterThan"/>
               </conditions>
               <modifiers>
                 <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="2"/>
@@ -510,75 +546,84 @@
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="ae7f-210d-3465-ed45" name="New CategoryLink" hidden="false" targetId="16bf-5402-ac6a-dab3" primary="true"/>
+        <categoryLink id="ae7f-210d-3465-ed45" name="Captain" hidden="false" targetId="16bf-5402-ac6a-dab3" primary="true"/>
         <categoryLink id="d4b5-9657-c842-a0f0" name="Faction: Stargrave Crew" hidden="false" targetId="7011-8c8a-78f8-283e" primary="false"/>
         <categoryLink id="e77d-ff66-ff01-8ddc" name="Core Robotics Expert" hidden="false" targetId="9d84-3333-57c7-92ea" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="84d5-3c86-a373-7475" name="Background" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="915c-e414-0eee-c3fd" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="283f-63d0-71f0-d767" type="max"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="915c-e414-0eee-c3fd" type="min"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="283f-63d0-71f0-d767" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="503d-f90c-3668-34c7" name="+1 Move" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d0b-4e15-1050-da67" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d0b-4e15-1050-da67" type="max"/>
               </constraints>
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b9d8-51e5-8551-87f6" name="+1 Fight" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="78a4-fcd7-61b2-4f6c" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="78a4-fcd7-61b2-4f6c" type="max"/>
               </constraints>
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="77c7-0bd2-1f34-e91e" name="+1 Health" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91dc-ae27-a2af-61eb" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91dc-ae27-a2af-61eb" type="max"/>
               </constraints>
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c206-f02f-3526-f5e2" name="+1 Shoot" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4722-52eb-02d4-900b" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4722-52eb-02d4-900b" type="max"/>
               </constraints>
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="b344-d18f-d509-7a50" name="Powers" hidden="false" collective="false" import="true" targetId="7753-4141-f613-ae54" type="selectionEntryGroup">
+        <selectionEntryGroup name="Powers" id="a303-ac52-55a9-4055" hidden="false">
+          <entryLinks>
+            <entryLink import="true" name="Core Powers" hidden="false" id="5cd3-85df-e54d-52ea" type="selectionEntryGroup" targetId="8f77-0290-5b40-2a4c">
+              <constraints>
+                <constraint type="min" value="3" field="selections" scope="parent" shared="true" id="ff87-25af-8baa-224a"/>
+                <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="b05f-9649-2bbe-de73"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Other Powers" hidden="false" id="ddd7-3b20-77b4-0373" type="selectionEntryGroup" targetId="d187-4aa6-4f21-7b77"/>
+          </entryLinks>
           <constraints>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="848a-b2f8-7afb-5c38" type="max"/>
+            <constraint type="max" value="5" field="selections" scope="parent" shared="true" id="393b-eb18-c1ff-2858"/>
           </constraints>
           <infoLinks>
-            <infoLink id="feb9-5090-8054-d156" name="Power Activation (Captain)" hidden="false" targetId="b036-a7e7-db3f-d23b" type="rule"/>
+            <infoLink name="Power Activation (Captain)" id="ddab-a8b4-92e0-ecdb" hidden="false" type="rule" targetId="b036-a7e7-db3f-d23b"/>
           </infoLinks>
-        </entryLink>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
         <entryLink id="e899-dedd-037f-5686" name="Equipment" hidden="false" collective="false" import="true" targetId="270a-a5c0-3695-1fe4" type="selectionEntryGroup">
           <constraints>
-            <constraint field="ef24-ff59-caa4-b0e8" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2e17-71b6-19e5-7dca" type="max"/>
+            <constraint field="ef24-ff59-caa4-b0e8" scope="parent" value="6" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2e17-71b6-19e5-7dca" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="da4d-ef57-ed71-fa18" name="Level" hidden="false" collective="false" import="true" targetId="4cd1-ff48-5eaf-e868" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="84fc-0ae6-ae73-c028" name="Rogue" hidden="false" collective="false" import="true" type="model">
@@ -587,34 +632,34 @@
           <modifiers>
             <modifier type="increment" field="dc65-e78a-d390-d9d5" value="1">
               <conditions>
-                <condition field="selections" scope="84fc-0ae6-ae73-c028" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c8f-0a9d-3cd8-b1e4" type="notEqualTo"/>
+                <condition field="selections" scope="84fc-0ae6-ae73-c028" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c8f-0a9d-3cd8-b1e4" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="453a-8ce6-f448-bb37" value="+4">
               <conditions>
-                <condition field="selections" scope="84fc-0ae6-ae73-c028" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5dc5-ef9e-029c-578c" type="notEqualTo"/>
+                <condition field="selections" scope="84fc-0ae6-ae73-c028" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5dc5-ef9e-029c-578c" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="d603-9472-1d68-663e" value="+3">
               <conditions>
-                <condition field="selections" scope="84fc-0ae6-ae73-c028" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e7b7-1a52-477b-a4d8" type="notEqualTo"/>
+                <condition field="selections" scope="84fc-0ae6-ae73-c028" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e7b7-1a52-477b-a4d8" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="1">
               <conditions>
-                <condition field="selections" scope="84fc-0ae6-ae73-c028" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c5f-174f-fa1f-26c7" type="greaterThan"/>
+                <condition field="selections" scope="84fc-0ae6-ae73-c028" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c5f-174f-fa1f-26c7" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="4">
               <conditions>
-                <condition field="selections" scope="84fc-0ae6-ae73-c028" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea4f-6372-4af1-e30b" type="greaterThan"/>
+                <condition field="selections" scope="84fc-0ae6-ae73-c028" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea4f-6372-4af1-e30b" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <modifierGroups>
             <modifierGroup>
               <conditions>
-                <condition field="selections" scope="84fc-0ae6-ae73-c028" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b824-fc04-4c55-b49e" type="greaterThan"/>
+                <condition field="selections" scope="84fc-0ae6-ae73-c028" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b824-fc04-4c55-b49e" type="greaterThan"/>
               </conditions>
               <modifiers>
                 <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="2"/>
@@ -633,66 +678,75 @@
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="507e-8c4a-6c57-0b45" name="New CategoryLink" hidden="false" targetId="16bf-5402-ac6a-dab3" primary="true"/>
+        <categoryLink id="507e-8c4a-6c57-0b45" name="Captain" hidden="false" targetId="16bf-5402-ac6a-dab3" primary="true"/>
         <categoryLink id="0d1a-aa0b-1477-c293" name="Faction: Stargrave Crew" hidden="false" targetId="7011-8c8a-78f8-283e" primary="false"/>
         <categoryLink id="aa17-e351-5291-6887" name="Core Rogue" hidden="false" targetId="8e49-f5d3-e9cd-c200" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="0796-7cb2-2bbe-9b1d" name="Background" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb0e-a346-9c87-3afc" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9138-71ef-c131-7022" type="max"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb0e-a346-9c87-3afc" type="min"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9138-71ef-c131-7022" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="2c8f-0a9d-3cd8-b1e4" name="+1 Move" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="63e1-3b96-a76d-32b8" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="63e1-3b96-a76d-32b8" type="max"/>
               </constraints>
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5dc5-ef9e-029c-578c" name="+1 Fight" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ecf7-c4d2-6e8a-5e0d" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ecf7-c4d2-6e8a-5e0d" type="max"/>
               </constraints>
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e7b7-1a52-477b-a4d8" name="+1 Shoot" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ccf-362d-0e0f-50f5" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ccf-362d-0e0f-50f5" type="max"/>
               </constraints>
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="5652-da95-4de6-e926" name="Powers" hidden="false" collective="false" import="true" targetId="7753-4141-f613-ae54" type="selectionEntryGroup">
+        <selectionEntryGroup name="Powers" id="c129-a340-f6b7-eb94" hidden="false">
+          <entryLinks>
+            <entryLink import="true" name="Core Powers" hidden="false" id="a176-a5ae-2947-b59b" type="selectionEntryGroup" targetId="8f77-0290-5b40-2a4c">
+              <constraints>
+                <constraint type="min" value="3" field="selections" scope="parent" shared="true" id="59ef-5486-a375-bb43"/>
+                <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="cf9d-619f-1971-30ac"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Other Powers" hidden="false" id="b30b-5207-51e6-ba95" type="selectionEntryGroup" targetId="d187-4aa6-4f21-7b77"/>
+          </entryLinks>
           <constraints>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4fbb-a548-75c3-0a3a" type="max"/>
+            <constraint type="max" value="5" field="selections" scope="parent" shared="true" id="fe81-c05b-5d06-e595"/>
           </constraints>
           <infoLinks>
-            <infoLink id="dfea-6fb1-ec3c-067c" name="Power Activation (Captain)" hidden="false" targetId="b036-a7e7-db3f-d23b" type="rule"/>
+            <infoLink name="Power Activation (Captain)" id="ad97-bacc-89ad-2d0f" hidden="false" type="rule" targetId="b036-a7e7-db3f-d23b"/>
           </infoLinks>
-        </entryLink>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
         <entryLink id="3bbc-87e1-f48d-2a78" name="Equipment" hidden="false" collective="false" import="true" targetId="270a-a5c0-3695-1fe4" type="selectionEntryGroup">
           <constraints>
-            <constraint field="ef24-ff59-caa4-b0e8" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="35da-5e76-765c-b445" type="max"/>
+            <constraint field="ef24-ff59-caa4-b0e8" scope="parent" value="6" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="35da-5e76-765c-b445" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="7161-f59e-c756-4519" name="Level" hidden="false" collective="false" import="true" targetId="4cd1-ff48-5eaf-e868" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9136-661e-90b6-fd97" name="Biomorph" hidden="false" collective="false" import="true" type="model">
@@ -701,34 +755,34 @@
           <modifiers>
             <modifier type="increment" field="dc65-e78a-d390-d9d5" value="1">
               <conditions>
-                <condition field="selections" scope="9136-661e-90b6-fd97" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d73c-c299-3d94-920a" type="notEqualTo"/>
+                <condition field="selections" scope="9136-661e-90b6-fd97" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d73c-c299-3d94-920a" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="453a-8ce6-f448-bb37" value="+4">
               <conditions>
-                <condition field="selections" scope="9136-661e-90b6-fd97" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5da0-36a4-e1b8-f091" type="notEqualTo"/>
+                <condition field="selections" scope="9136-661e-90b6-fd97" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5da0-36a4-e1b8-f091" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="d603-9472-1d68-663e" value="+3">
               <conditions>
-                <condition field="selections" scope="9136-661e-90b6-fd97" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="32b5-8aa4-780a-32f6" type="notEqualTo"/>
+                <condition field="selections" scope="9136-661e-90b6-fd97" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="32b5-8aa4-780a-32f6" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="1">
               <conditions>
-                <condition field="selections" scope="9136-661e-90b6-fd97" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c5f-174f-fa1f-26c7" type="greaterThan"/>
+                <condition field="selections" scope="9136-661e-90b6-fd97" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c5f-174f-fa1f-26c7" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="4">
               <conditions>
-                <condition field="selections" scope="9136-661e-90b6-fd97" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea4f-6372-4af1-e30b" type="greaterThan"/>
+                <condition field="selections" scope="9136-661e-90b6-fd97" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea4f-6372-4af1-e30b" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <modifierGroups>
             <modifierGroup>
               <conditions>
-                <condition field="selections" scope="9136-661e-90b6-fd97" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b824-fc04-4c55-b49e" type="greaterThan"/>
+                <condition field="selections" scope="9136-661e-90b6-fd97" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b824-fc04-4c55-b49e" type="greaterThan"/>
               </conditions>
               <modifiers>
                 <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="2"/>
@@ -747,66 +801,75 @@
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="86c6-aab1-08c0-1777" name="New CategoryLink" hidden="false" targetId="16bf-5402-ac6a-dab3" primary="true"/>
+        <categoryLink id="86c6-aab1-08c0-1777" name="Captain" hidden="false" targetId="16bf-5402-ac6a-dab3" primary="true"/>
         <categoryLink id="f0b7-a6a3-6835-3555" name="Faction: Stargrave Crew" hidden="false" targetId="7011-8c8a-78f8-283e" primary="false"/>
         <categoryLink id="7327-32d0-7b9b-7d3a" name="Core Biomorph" hidden="false" targetId="6939-3fb3-687a-2a0b" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="a253-5a7a-0b29-69e8" name="Background" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3792-933b-9088-ff04" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b7f-e379-9210-ba7a" type="max"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3792-933b-9088-ff04" type="min"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b7f-e379-9210-ba7a" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="d73c-c299-3d94-920a" name="+1 Move" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c11-965d-74a2-7870" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c11-965d-74a2-7870" type="max"/>
               </constraints>
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5da0-36a4-e1b8-f091" name="+1 Fight" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10f9-d9dc-3e90-34c7" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10f9-d9dc-3e90-34c7" type="max"/>
               </constraints>
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="32b5-8aa4-780a-32f6" name="+1 Shoot" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ed9-43e2-d2a5-2de5" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ed9-43e2-d2a5-2de5" type="max"/>
               </constraints>
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="1dc2-7bfe-92d1-a883" name="Powers" hidden="false" collective="false" import="true" targetId="7753-4141-f613-ae54" type="selectionEntryGroup">
+        <selectionEntryGroup name="Powers" id="ce2f-5ed0-b359-26d3" hidden="false">
+          <entryLinks>
+            <entryLink import="true" name="Core Powers" hidden="false" id="3202-65ee-1f18-9a6b" type="selectionEntryGroup" targetId="8f77-0290-5b40-2a4c">
+              <constraints>
+                <constraint type="min" value="3" field="selections" scope="parent" shared="true" id="ab9c-4487-9be5-f5df"/>
+                <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="cff2-c051-4580-1fec"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Other Powers" hidden="false" id="ff81-ed6d-cd53-eea7" type="selectionEntryGroup" targetId="d187-4aa6-4f21-7b77"/>
+          </entryLinks>
           <constraints>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ee4d-a847-3f37-7985" type="max"/>
+            <constraint type="max" value="5" field="selections" scope="parent" shared="true" id="77ea-1af0-5e7d-a0e1"/>
           </constraints>
           <infoLinks>
-            <infoLink id="14dd-cb50-3095-872d" name="Power Activation (Captain)" hidden="false" targetId="b036-a7e7-db3f-d23b" type="rule"/>
+            <infoLink name="Power Activation (Captain)" id="820a-9bef-9ae9-e923" hidden="false" type="rule" targetId="b036-a7e7-db3f-d23b"/>
           </infoLinks>
-        </entryLink>
-        <entryLink id="292c-9e8b-930d-8ff6" name="Gears" hidden="false" collective="false" import="true" targetId="270a-a5c0-3695-1fe4" type="selectionEntryGroup">
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="292c-9e8b-930d-8ff6" name="Equipment" hidden="false" collective="false" import="true" targetId="270a-a5c0-3695-1fe4" type="selectionEntryGroup">
           <constraints>
-            <constraint field="ef24-ff59-caa4-b0e8" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d639-8402-d3d8-56d8" type="max"/>
+            <constraint field="ef24-ff59-caa4-b0e8" scope="parent" value="6" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d639-8402-d3d8-56d8" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="29e2-57ab-4e4e-28ab" name="Level" hidden="false" collective="false" import="true" targetId="4cd1-ff48-5eaf-e868" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9d6d-a32d-7054-364c" name="First Mate Cyborg" hidden="false" collective="false" import="true" type="model">
@@ -815,34 +878,34 @@
           <modifiers>
             <modifier type="increment" field="dc65-e78a-d390-d9d5" value="1">
               <conditions>
-                <condition field="selections" scope="9d6d-a32d-7054-364c" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2b42-bb84-9912-648e" type="notEqualTo"/>
+                <condition field="selections" scope="9d6d-a32d-7054-364c" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2b42-bb84-9912-648e" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="453a-8ce6-f448-bb37" value="+3">
               <conditions>
-                <condition field="selections" scope="9d6d-a32d-7054-364c" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3323-4c53-a815-4277" type="notEqualTo"/>
+                <condition field="selections" scope="9d6d-a32d-7054-364c" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3323-4c53-a815-4277" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="d603-9472-1d68-663e" value="+3">
               <conditions>
-                <condition field="selections" scope="9d6d-a32d-7054-364c" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="aab4-ecb5-ea16-e3f5" type="notEqualTo"/>
+                <condition field="selections" scope="9d6d-a32d-7054-364c" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="aab4-ecb5-ea16-e3f5" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="1">
               <conditions>
-                <condition field="selections" scope="9d6d-a32d-7054-364c" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c5f-174f-fa1f-26c7" type="greaterThan"/>
+                <condition field="selections" scope="9d6d-a32d-7054-364c" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c5f-174f-fa1f-26c7" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="4">
               <conditions>
-                <condition field="selections" scope="9d6d-a32d-7054-364c" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea4f-6372-4af1-e30b" type="greaterThan"/>
+                <condition field="selections" scope="9d6d-a32d-7054-364c" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea4f-6372-4af1-e30b" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <modifierGroups>
             <modifierGroup>
               <conditions>
-                <condition field="selections" scope="9d6d-a32d-7054-364c" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b824-fc04-4c55-b49e" type="greaterThan"/>
+                <condition field="selections" scope="9d6d-a32d-7054-364c" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b824-fc04-4c55-b49e" type="greaterThan"/>
               </conditions>
               <modifiers>
                 <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="2"/>
@@ -862,65 +925,74 @@
       </profiles>
       <categoryLinks>
         <categoryLink id="419f-8d93-437f-5d37" name="Faction: Stargrave Crew" hidden="false" targetId="7011-8c8a-78f8-283e" primary="false"/>
-        <categoryLink id="2660-2790-ff55-079d" name="New CategoryLink" hidden="false" targetId="8749-37ea-6f9e-0824" primary="true"/>
+        <categoryLink id="2660-2790-ff55-079d" name="First Mate" hidden="false" targetId="8749-37ea-6f9e-0824" primary="true"/>
         <categoryLink id="69c5-3f47-9c2c-2679" name="Core Cyborg" hidden="false" targetId="1795-c4e8-6ca2-380b" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="a8ab-62ad-974c-cf58" name="Background" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d77f-a8ff-ee86-1322" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ef4-346e-2546-3367" type="max"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d77f-a8ff-ee86-1322" type="min"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ef4-346e-2546-3367" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="2b42-bb84-9912-648e" name="+1 Move" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b105-409f-9481-6993" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b105-409f-9481-6993" type="max"/>
               </constraints>
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3323-4c53-a815-4277" name="+1 Fight" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd82-c490-9004-4c20" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd82-c490-9004-4c20" type="max"/>
               </constraints>
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="aab4-ecb5-ea16-e3f5" name="+1 Shoot" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc47-8de5-1516-a151" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc47-8de5-1516-a151" type="max"/>
               </constraints>
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="7a5a-a695-4ca1-0b54" name="Powers" hidden="false" collective="false" import="true" targetId="7753-4141-f613-ae54" type="selectionEntryGroup">
+        <selectionEntryGroup name="Powers" id="3e07-7045-a9b4-7267" hidden="false">
+          <entryLinks>
+            <entryLink import="true" name="Core Powers" hidden="false" id="7765-a7b7-83a8-eede" type="selectionEntryGroup" targetId="8f77-0290-5b40-2a4c">
+              <constraints>
+                <constraint type="min" value="2" field="selections" scope="parent" shared="true" id="4bde-30a7-0600-8508"/>
+                <constraint type="max" value="3" field="selections" scope="parent" shared="true" id="3e24-b971-3150-2572"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Other Powers" hidden="false" id="7345-a262-8d87-464b" type="selectionEntryGroup" targetId="d187-4aa6-4f21-7b77"/>
+          </entryLinks>
           <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fd3b-9a51-a7f1-130b" type="max"/>
+            <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="e863-aeb8-3263-690e"/>
           </constraints>
           <infoLinks>
-            <infoLink id="5064-116a-a9a1-3399" name="Power Activation (First Mate)" hidden="false" targetId="6819-fdeb-c82b-4b42" type="rule"/>
+            <infoLink name="Power Activation (First Mate)" id="be3f-bd0b-1f94-eca5" hidden="false" type="rule" targetId="6819-fdeb-c82b-4b42"/>
           </infoLinks>
-        </entryLink>
-        <entryLink id="0b6e-c1c6-5bc0-479f" name="Gears" hidden="false" collective="false" import="true" targetId="270a-a5c0-3695-1fe4" type="selectionEntryGroup">
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="0b6e-c1c6-5bc0-479f" name="Equipment" hidden="false" collective="false" import="true" targetId="270a-a5c0-3695-1fe4" type="selectionEntryGroup">
           <constraints>
-            <constraint field="ef24-ff59-caa4-b0e8" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="990d-73ed-22dd-7017" type="max"/>
+            <constraint field="ef24-ff59-caa4-b0e8" scope="parent" value="5" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="990d-73ed-22dd-7017" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="18fe-cde1-1fd3-7c2c" name="Level" hidden="false" collective="false" import="true" targetId="4cd1-ff48-5eaf-e868" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="36d1-0a6b-8a65-fe71" name="Mystic" hidden="false" collective="false" import="true" type="model">
@@ -929,34 +1001,34 @@
           <modifiers>
             <modifier type="increment" field="dc65-e78a-d390-d9d5" value="1">
               <conditions>
-                <condition field="selections" scope="36d1-0a6b-8a65-fe71" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dc76-34c8-afd6-b5dd" type="notEqualTo"/>
+                <condition field="selections" scope="36d1-0a6b-8a65-fe71" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dc76-34c8-afd6-b5dd" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="453a-8ce6-f448-bb37" value="+4">
               <conditions>
-                <condition field="selections" scope="36d1-0a6b-8a65-fe71" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c946-3359-82a7-829f" type="notEqualTo"/>
+                <condition field="selections" scope="36d1-0a6b-8a65-fe71" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c946-3359-82a7-829f" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="d603-9472-1d68-663e" value="+3">
               <conditions>
-                <condition field="selections" scope="36d1-0a6b-8a65-fe71" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="457d-79d2-2714-50c1" type="notEqualTo"/>
+                <condition field="selections" scope="36d1-0a6b-8a65-fe71" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="457d-79d2-2714-50c1" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="1">
               <conditions>
-                <condition field="selections" scope="36d1-0a6b-8a65-fe71" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c5f-174f-fa1f-26c7" type="greaterThan"/>
+                <condition field="selections" scope="36d1-0a6b-8a65-fe71" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c5f-174f-fa1f-26c7" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="4">
               <conditions>
-                <condition field="selections" scope="36d1-0a6b-8a65-fe71" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea4f-6372-4af1-e30b" type="greaterThan"/>
+                <condition field="selections" scope="36d1-0a6b-8a65-fe71" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea4f-6372-4af1-e30b" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <modifierGroups>
             <modifierGroup>
               <conditions>
-                <condition field="selections" scope="36d1-0a6b-8a65-fe71" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b824-fc04-4c55-b49e" type="greaterThan"/>
+                <condition field="selections" scope="36d1-0a6b-8a65-fe71" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b824-fc04-4c55-b49e" type="greaterThan"/>
               </conditions>
               <modifiers>
                 <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="2"/>
@@ -975,57 +1047,66 @@
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="d598-3c9e-508d-638d" name="New CategoryLink" hidden="false" targetId="16bf-5402-ac6a-dab3" primary="true"/>
+        <categoryLink id="d598-3c9e-508d-638d" name="Captain" hidden="false" targetId="16bf-5402-ac6a-dab3" primary="true"/>
         <categoryLink id="cfae-8e4d-1df1-5f88" name="Faction: Stargrave Crew" hidden="false" targetId="7011-8c8a-78f8-283e" primary="false"/>
         <categoryLink id="b899-829e-71e6-4086" name="Core Mystic" hidden="false" targetId="2934-b054-68dc-0468" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="1c92-a4e1-b741-d48b" name="Background" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="baff-d7cb-3514-c47d" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2027-c20f-63a5-94bf" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="baff-d7cb-3514-c47d" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2027-c20f-63a5-94bf" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="dc76-34c8-afd6-b5dd" name="+1 Move" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c946-3359-82a7-829f" name="+1 Fight" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="457d-79d2-2714-50c1" name="+1 Shoot" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="605f-4369-c8c9-3e1d" name="Powers" hidden="false" collective="false" import="true" targetId="7753-4141-f613-ae54" type="selectionEntryGroup">
+        <selectionEntryGroup name="Powers" id="5eb2-ce66-bce5-4fef" hidden="false">
+          <entryLinks>
+            <entryLink import="true" name="Core Powers" hidden="false" id="589d-f86d-50fb-286a" type="selectionEntryGroup" targetId="8f77-0290-5b40-2a4c">
+              <constraints>
+                <constraint type="min" value="3" field="selections" scope="parent" shared="true" id="5497-86b2-1756-f617"/>
+                <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="8b64-7221-f4c7-59ca"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Other Powers" hidden="false" id="197b-abfc-cafe-7d56" type="selectionEntryGroup" targetId="d187-4aa6-4f21-7b77"/>
+          </entryLinks>
           <constraints>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e418-62fb-0b6a-394f" type="max"/>
+            <constraint type="max" value="5" field="selections" scope="parent" shared="true" id="9109-53d1-fa8e-e113"/>
           </constraints>
           <infoLinks>
-            <infoLink id="eebf-4f24-4cbf-4b3b" name="Power Activation (Captain)" hidden="false" targetId="b036-a7e7-db3f-d23b" type="rule"/>
+            <infoLink name="Power Activation (Captain)" id="93df-6292-070e-47c5" hidden="false" type="rule" targetId="b036-a7e7-db3f-d23b"/>
           </infoLinks>
-        </entryLink>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
         <entryLink id="9699-c2a9-044c-3cab" name="Equipment" hidden="false" collective="false" import="true" targetId="270a-a5c0-3695-1fe4" type="selectionEntryGroup">
           <constraints>
-            <constraint field="ef24-ff59-caa4-b0e8" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d7cb-bbc1-a503-360e" type="max"/>
+            <constraint field="ef24-ff59-caa4-b0e8" scope="parent" value="6" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d7cb-bbc1-a503-360e" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="5652-961b-fa02-ddfb" name="Level" hidden="false" collective="false" import="true" targetId="4cd1-ff48-5eaf-e868" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="b3fd-a4d7-4d23-f7ce" name="Cyborg" hidden="false" collective="false" import="true" type="model">
@@ -1034,34 +1115,34 @@
           <modifiers>
             <modifier type="increment" field="dc65-e78a-d390-d9d5" value="1">
               <conditions>
-                <condition field="selections" scope="b3fd-a4d7-4d23-f7ce" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7734-23e1-a774-b7e9" type="notEqualTo"/>
+                <condition field="selections" scope="b3fd-a4d7-4d23-f7ce" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7734-23e1-a774-b7e9" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="453a-8ce6-f448-bb37" value="+4">
               <conditions>
-                <condition field="selections" scope="b3fd-a4d7-4d23-f7ce" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="11f3-e54d-39ef-8381" type="notEqualTo"/>
+                <condition field="selections" scope="b3fd-a4d7-4d23-f7ce" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="11f3-e54d-39ef-8381" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="d603-9472-1d68-663e" value="+3">
               <conditions>
-                <condition field="selections" scope="b3fd-a4d7-4d23-f7ce" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3b44-2734-bc3c-bb51" type="notEqualTo"/>
+                <condition field="selections" scope="b3fd-a4d7-4d23-f7ce" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3b44-2734-bc3c-bb51" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="1">
               <conditions>
-                <condition field="selections" scope="b3fd-a4d7-4d23-f7ce" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c5f-174f-fa1f-26c7" type="greaterThan"/>
+                <condition field="selections" scope="b3fd-a4d7-4d23-f7ce" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c5f-174f-fa1f-26c7" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="4">
               <conditions>
-                <condition field="selections" scope="b3fd-a4d7-4d23-f7ce" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea4f-6372-4af1-e30b" type="greaterThan"/>
+                <condition field="selections" scope="b3fd-a4d7-4d23-f7ce" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea4f-6372-4af1-e30b" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <modifierGroups>
             <modifierGroup>
               <conditions>
-                <condition field="selections" scope="b3fd-a4d7-4d23-f7ce" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b824-fc04-4c55-b49e" type="greaterThan"/>
+                <condition field="selections" scope="b3fd-a4d7-4d23-f7ce" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b824-fc04-4c55-b49e" type="greaterThan"/>
               </conditions>
               <modifiers>
                 <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="2"/>
@@ -1080,66 +1161,75 @@
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="7c59-dbc4-636b-ac65" name="New CategoryLink" hidden="false" targetId="16bf-5402-ac6a-dab3" primary="true"/>
+        <categoryLink id="7c59-dbc4-636b-ac65" name="Captain" hidden="false" targetId="16bf-5402-ac6a-dab3" primary="true"/>
         <categoryLink id="d37b-517c-e43c-420d" name="Faction: Stargrave Crew" hidden="false" targetId="7011-8c8a-78f8-283e" primary="false"/>
         <categoryLink id="1a8a-68d7-a518-a9a2" name="Core Cyborg" hidden="false" targetId="1795-c4e8-6ca2-380b" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="81d5-9e98-4704-c64e" name="Background" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a1d6-23df-fbfa-5002" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="64a6-b661-b633-9fb4" type="max"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a1d6-23df-fbfa-5002" type="min"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="64a6-b661-b633-9fb4" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="7734-23e1-a774-b7e9" name="+1 Move" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="903b-6892-3a0f-2ef5" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="903b-6892-3a0f-2ef5" type="max"/>
               </constraints>
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="11f3-e54d-39ef-8381" name="+1 Fight" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e596-2700-aed6-c065" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e596-2700-aed6-c065" type="max"/>
               </constraints>
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3b44-2734-bc3c-bb51" name="+1 Shoot" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3ae-ae66-0dc1-41be" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3ae-ae66-0dc1-41be" type="max"/>
               </constraints>
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="9b4f-03e8-bda8-4b8a" name="Powers" hidden="false" collective="false" import="true" targetId="7753-4141-f613-ae54" type="selectionEntryGroup">
+        <selectionEntryGroup name="Powers" id="45dc-7913-62e7-bbdb" hidden="false">
+          <entryLinks>
+            <entryLink import="true" name="Core Powers" hidden="false" id="6f24-50d3-f9f8-d05a" type="selectionEntryGroup" targetId="8f77-0290-5b40-2a4c">
+              <constraints>
+                <constraint type="min" value="3" field="selections" scope="parent" shared="true" id="4185-dacf-63dc-2344"/>
+                <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="069a-674b-13a2-60a8"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Other Powers" hidden="false" id="63f1-0390-e54d-7371" type="selectionEntryGroup" targetId="d187-4aa6-4f21-7b77"/>
+          </entryLinks>
           <constraints>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0509-5e59-ba6b-7bc2" type="max"/>
+            <constraint type="max" value="5" field="selections" scope="parent" shared="true" id="22ef-a6f4-8bf7-1989"/>
           </constraints>
           <infoLinks>
-            <infoLink id="0735-92b9-8ac8-9147" name="Power Activation (Captain)" hidden="false" targetId="b036-a7e7-db3f-d23b" type="rule"/>
+            <infoLink name="Power Activation (Captain)" id="2b8f-4cb8-0085-d088" hidden="false" type="rule" targetId="b036-a7e7-db3f-d23b"/>
           </infoLinks>
-        </entryLink>
-        <entryLink id="6d7c-c969-c03b-93ce" name="Gears" hidden="false" collective="false" import="true" targetId="270a-a5c0-3695-1fe4" type="selectionEntryGroup">
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="6d7c-c969-c03b-93ce" name="Equipment" hidden="false" collective="false" import="true" targetId="270a-a5c0-3695-1fe4" type="selectionEntryGroup">
           <constraints>
-            <constraint field="ef24-ff59-caa4-b0e8" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a9b3-d1fa-fb48-2d27" type="max"/>
+            <constraint field="ef24-ff59-caa4-b0e8" scope="parent" value="6" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a9b3-d1fa-fb48-2d27" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="cf3b-2653-070f-dcb7" name="Level" hidden="false" collective="false" import="true" targetId="4cd1-ff48-5eaf-e868" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="703b-b594-1549-7ce4" name="First Mate Mystic" hidden="false" collective="false" import="true" type="model">
@@ -1148,34 +1238,34 @@
           <modifiers>
             <modifier type="increment" field="dc65-e78a-d390-d9d5" value="1">
               <conditions>
-                <condition field="selections" scope="703b-b594-1549-7ce4" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a6ea-b2c7-a441-cb87" type="notEqualTo"/>
+                <condition field="selections" scope="703b-b594-1549-7ce4" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a6ea-b2c7-a441-cb87" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="453a-8ce6-f448-bb37" value="+3">
               <conditions>
-                <condition field="selections" scope="703b-b594-1549-7ce4" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="11db-61bb-a94b-227c" type="notEqualTo"/>
+                <condition field="selections" scope="703b-b594-1549-7ce4" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="11db-61bb-a94b-227c" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="d603-9472-1d68-663e" value="+3">
               <conditions>
-                <condition field="selections" scope="703b-b594-1549-7ce4" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b59d-7931-829d-a558" type="notEqualTo"/>
+                <condition field="selections" scope="703b-b594-1549-7ce4" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b59d-7931-829d-a558" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="1">
               <conditions>
-                <condition field="selections" scope="703b-b594-1549-7ce4" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c5f-174f-fa1f-26c7" type="greaterThan"/>
+                <condition field="selections" scope="703b-b594-1549-7ce4" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c5f-174f-fa1f-26c7" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="4">
               <conditions>
-                <condition field="selections" scope="703b-b594-1549-7ce4" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea4f-6372-4af1-e30b" type="greaterThan"/>
+                <condition field="selections" scope="703b-b594-1549-7ce4" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea4f-6372-4af1-e30b" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <modifierGroups>
             <modifierGroup>
               <conditions>
-                <condition field="selections" scope="703b-b594-1549-7ce4" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b824-fc04-4c55-b49e" type="greaterThan"/>
+                <condition field="selections" scope="703b-b594-1549-7ce4" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b824-fc04-4c55-b49e" type="greaterThan"/>
               </conditions>
               <modifiers>
                 <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="2"/>
@@ -1195,56 +1285,65 @@
       </profiles>
       <categoryLinks>
         <categoryLink id="cb96-0bb8-86b0-3c55" name="Faction: Stargrave Crew" hidden="false" targetId="7011-8c8a-78f8-283e" primary="false"/>
-        <categoryLink id="a942-8ca7-000e-8ad5" name="New CategoryLink" hidden="false" targetId="8749-37ea-6f9e-0824" primary="true"/>
+        <categoryLink id="a942-8ca7-000e-8ad5" name="First Mate" hidden="false" targetId="8749-37ea-6f9e-0824" primary="true"/>
         <categoryLink id="f939-e75d-95a0-cde9" name="Core Mystic" hidden="false" targetId="2934-b054-68dc-0468" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="3fb3-ece1-7d5b-2aab" name="Background" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac23-f4b2-e225-e94a" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="42f2-e40c-ebb2-09c7" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac23-f4b2-e225-e94a" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="42f2-e40c-ebb2-09c7" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="a6ea-b2c7-a441-cb87" name="+1 Move" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="11db-61bb-a94b-227c" name="+1 Fight" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b59d-7931-829d-a558" name="+1 Shoot" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="6619-6e9d-2ec4-ba96" name="Powers" hidden="false" collective="false" import="true" targetId="7753-4141-f613-ae54" type="selectionEntryGroup">
+        <selectionEntryGroup name="Powers" id="7be6-cb37-fb0e-280a" hidden="false">
+          <entryLinks>
+            <entryLink import="true" name="Core Powers" hidden="false" id="90cd-65d7-74b4-c0e6" type="selectionEntryGroup" targetId="8f77-0290-5b40-2a4c">
+              <constraints>
+                <constraint type="min" value="2" field="selections" scope="parent" shared="true" id="c700-364a-11f4-4c8c"/>
+                <constraint type="max" value="3" field="selections" scope="parent" shared="true" id="6ff1-fb4b-fa57-ce6e"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Other Powers" hidden="false" id="2a52-2451-42dd-bd56" type="selectionEntryGroup" targetId="d187-4aa6-4f21-7b77"/>
+          </entryLinks>
           <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="521c-6859-ba86-c240" type="max"/>
+            <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="503f-d0f2-4d78-e1c9"/>
           </constraints>
           <infoLinks>
-            <infoLink id="1227-a8e7-9b33-5462" name="Power Activation (First Mate)" hidden="false" targetId="6819-fdeb-c82b-4b42" type="rule"/>
+            <infoLink name="Power Activation (First Mate)" id="6c42-52c1-b546-745a" hidden="false" type="rule" targetId="6819-fdeb-c82b-4b42"/>
           </infoLinks>
-        </entryLink>
-        <entryLink id="7f77-d8bd-3497-2652" name="Gears" hidden="false" collective="false" import="true" targetId="270a-a5c0-3695-1fe4" type="selectionEntryGroup">
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="7f77-d8bd-3497-2652" name="Equipment" hidden="false" collective="false" import="true" targetId="270a-a5c0-3695-1fe4" type="selectionEntryGroup">
           <constraints>
-            <constraint field="ef24-ff59-caa4-b0e8" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7fff-bc95-58eb-e5db" type="max"/>
+            <constraint field="ef24-ff59-caa4-b0e8" scope="parent" value="5" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7fff-bc95-58eb-e5db" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="6117-60d1-8069-1e95" name="Level" hidden="false" collective="false" import="true" targetId="4cd1-ff48-5eaf-e868" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="dd7b-042e-4d07-7f8e" name="First Mate Psionicist" hidden="false" collective="false" import="true" type="model">
@@ -1253,34 +1352,34 @@
           <modifiers>
             <modifier type="increment" field="dc65-e78a-d390-d9d5" value="1">
               <conditions>
-                <condition field="selections" scope="dd7b-042e-4d07-7f8e" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="38bc-3e72-5ad6-9efc" type="notEqualTo"/>
+                <condition field="selections" scope="dd7b-042e-4d07-7f8e" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="38bc-3e72-5ad6-9efc" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="d603-9472-1d68-663e" value="+3">
               <conditions>
-                <condition field="selections" scope="dd7b-042e-4d07-7f8e" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fa77-54db-3456-86e5" type="notEqualTo"/>
+                <condition field="selections" scope="dd7b-042e-4d07-7f8e" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fa77-54db-3456-86e5" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="453a-8ce6-f448-bb37" value="+3">
               <conditions>
-                <condition field="selections" scope="dd7b-042e-4d07-7f8e" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="905d-6d81-90cc-1067" type="notEqualTo"/>
+                <condition field="selections" scope="dd7b-042e-4d07-7f8e" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="905d-6d81-90cc-1067" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="4">
               <conditions>
-                <condition field="selections" scope="dd7b-042e-4d07-7f8e" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea4f-6372-4af1-e30b" type="greaterThan"/>
+                <condition field="selections" scope="dd7b-042e-4d07-7f8e" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea4f-6372-4af1-e30b" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="1">
               <conditions>
-                <condition field="selections" scope="dd7b-042e-4d07-7f8e" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c5f-174f-fa1f-26c7" type="greaterThan"/>
+                <condition field="selections" scope="dd7b-042e-4d07-7f8e" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c5f-174f-fa1f-26c7" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <modifierGroups>
             <modifierGroup>
               <conditions>
-                <condition field="selections" scope="dd7b-042e-4d07-7f8e" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b824-fc04-4c55-b49e" type="greaterThan"/>
+                <condition field="selections" scope="dd7b-042e-4d07-7f8e" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b824-fc04-4c55-b49e" type="greaterThan"/>
               </conditions>
               <modifiers>
                 <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="2"/>
@@ -1300,56 +1399,65 @@
       </profiles>
       <categoryLinks>
         <categoryLink id="573b-142b-f363-c8f9" name="Faction: Stargrave Crew" hidden="false" targetId="7011-8c8a-78f8-283e" primary="false"/>
-        <categoryLink id="43af-9fdd-02b8-fb8c" name="New CategoryLink" hidden="false" targetId="8749-37ea-6f9e-0824" primary="true"/>
+        <categoryLink id="43af-9fdd-02b8-fb8c" name="First Mate" hidden="false" targetId="8749-37ea-6f9e-0824" primary="true"/>
         <categoryLink id="9607-cd4b-c4ef-ed40" name="Core Psionicist" hidden="false" targetId="9e36-ac96-3132-f141" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="719e-1c33-b21e-8e1e" name="Background" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c060-fd7c-d53b-9dbb" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="06de-a94c-5d20-368f" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c060-fd7c-d53b-9dbb" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="06de-a94c-5d20-368f" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="38bc-3e72-5ad6-9efc" name="+1 Move" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="905d-6d81-90cc-1067" name="+1 Fight" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fa77-54db-3456-86e5" name="+1 Shoot" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="63f5-e67a-d948-bec1" name="Powers" hidden="false" collective="false" import="true" targetId="7753-4141-f613-ae54" type="selectionEntryGroup">
+        <selectionEntryGroup name="Powers" id="3cb1-82ec-35b7-6689" hidden="false">
+          <entryLinks>
+            <entryLink import="true" name="Core Powers" hidden="false" id="3f47-8fe7-2bea-2399" type="selectionEntryGroup" targetId="8f77-0290-5b40-2a4c">
+              <constraints>
+                <constraint type="min" value="2" field="selections" scope="parent" shared="true" id="e02f-dece-e73e-f35e"/>
+                <constraint type="max" value="3" field="selections" scope="parent" shared="true" id="574b-7168-a417-ba5d"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Other Powers" hidden="false" id="3028-fd02-c585-6dd2" type="selectionEntryGroup" targetId="d187-4aa6-4f21-7b77"/>
+          </entryLinks>
           <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="009b-bcdd-84c5-11e4" type="max"/>
+            <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="9805-c681-a836-c51f"/>
           </constraints>
           <infoLinks>
-            <infoLink id="ac7d-d124-89b4-1bce" name="Power Activation (First Mate)" hidden="false" targetId="6819-fdeb-c82b-4b42" type="rule"/>
+            <infoLink name="Power Activation (First Mate)" id="07bb-ca27-0e91-c630" hidden="false" type="rule" targetId="6819-fdeb-c82b-4b42"/>
           </infoLinks>
-        </entryLink>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
         <entryLink id="c474-37f1-10d9-83c4" name="Equipment" hidden="false" collective="false" import="true" targetId="270a-a5c0-3695-1fe4" type="selectionEntryGroup">
           <constraints>
-            <constraint field="ef24-ff59-caa4-b0e8" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4532-e861-ab93-dd10" type="max"/>
+            <constraint field="ef24-ff59-caa4-b0e8" scope="parent" value="5" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4532-e861-ab93-dd10" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="3b57-0082-c9c0-5723" name="Level" hidden="false" collective="false" import="true" targetId="4cd1-ff48-5eaf-e868" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7caf-92d2-2c83-f857" name="First Mate Robotics Expert" hidden="false" collective="false" import="true" type="model">
@@ -1358,39 +1466,39 @@
           <modifiers>
             <modifier type="increment" field="c25e-02c0-2580-ff3c" value="1">
               <conditions>
-                <condition field="selections" scope="7caf-92d2-2c83-f857" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="db90-74d0-aa74-43c5" type="notEqualTo"/>
+                <condition field="selections" scope="7caf-92d2-2c83-f857" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="db90-74d0-aa74-43c5" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="dc65-e78a-d390-d9d5" value="1">
               <conditions>
-                <condition field="selections" scope="7caf-92d2-2c83-f857" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d4e4-a2fa-77c4-413e" type="notEqualTo"/>
+                <condition field="selections" scope="7caf-92d2-2c83-f857" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d4e4-a2fa-77c4-413e" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="453a-8ce6-f448-bb37" value="+4">
               <conditions>
-                <condition field="selections" scope="7caf-92d2-2c83-f857" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="540a-a336-a6fc-6aea" type="notEqualTo"/>
+                <condition field="selections" scope="7caf-92d2-2c83-f857" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="540a-a336-a6fc-6aea" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="d603-9472-1d68-663e" value="+3">
               <conditions>
-                <condition field="selections" scope="7caf-92d2-2c83-f857" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5cb8-80c4-3a0f-3eb8" type="notEqualTo"/>
+                <condition field="selections" scope="7caf-92d2-2c83-f857" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5cb8-80c4-3a0f-3eb8" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="1">
               <conditions>
-                <condition field="selections" scope="7caf-92d2-2c83-f857" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c5f-174f-fa1f-26c7" type="greaterThan"/>
+                <condition field="selections" scope="7caf-92d2-2c83-f857" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c5f-174f-fa1f-26c7" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="4">
               <conditions>
-                <condition field="selections" scope="7caf-92d2-2c83-f857" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea4f-6372-4af1-e30b" type="greaterThan"/>
+                <condition field="selections" scope="7caf-92d2-2c83-f857" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea4f-6372-4af1-e30b" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <modifierGroups>
             <modifierGroup>
               <conditions>
-                <condition field="selections" scope="7caf-92d2-2c83-f857" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b824-fc04-4c55-b49e" type="greaterThan"/>
+                <condition field="selections" scope="7caf-92d2-2c83-f857" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b824-fc04-4c55-b49e" type="greaterThan"/>
               </conditions>
               <modifiers>
                 <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="2"/>
@@ -1410,74 +1518,83 @@
       </profiles>
       <categoryLinks>
         <categoryLink id="b906-f815-88e5-7daf" name="Faction: Stargrave Crew" hidden="false" targetId="7011-8c8a-78f8-283e" primary="false"/>
-        <categoryLink id="77ed-f571-ba1a-5a81" name="New CategoryLink" hidden="false" targetId="8749-37ea-6f9e-0824" primary="true"/>
+        <categoryLink id="77ed-f571-ba1a-5a81" name="First Mate" hidden="false" targetId="8749-37ea-6f9e-0824" primary="true"/>
         <categoryLink id="7835-a316-f5ad-5af1" name="Core Robotics Expert" hidden="false" targetId="9d84-3333-57c7-92ea" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="032c-91c2-68db-0a89" name="Background" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f99c-d6d5-b585-61a0" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c41-7395-b154-56d1" type="max"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f99c-d6d5-b585-61a0" type="min"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c41-7395-b154-56d1" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="d4e4-a2fa-77c4-413e" name="+1 Move" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5667-ee7e-7511-65ca" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5667-ee7e-7511-65ca" type="max"/>
               </constraints>
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="540a-a336-a6fc-6aea" name="+1 Fight" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a83b-69fc-d4cc-8b8d" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a83b-69fc-d4cc-8b8d" type="max"/>
               </constraints>
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="db90-74d0-aa74-43c5" name="+1 Health" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ed9-1451-2669-1c17" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ed9-1451-2669-1c17" type="max"/>
               </constraints>
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5cb8-80c4-3a0f-3eb8" name="+1 Shoot" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e07a-f39c-3561-fe5d" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e07a-f39c-3561-fe5d" type="max"/>
               </constraints>
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="febb-5c76-6688-270e" name="Powers" hidden="false" collective="false" import="true" targetId="7753-4141-f613-ae54" type="selectionEntryGroup">
+        <selectionEntryGroup name="Powers" id="f2b4-0bd5-1443-3cd9" hidden="false">
+          <entryLinks>
+            <entryLink import="true" name="Core Powers" hidden="false" id="5264-f199-5c24-b51f" type="selectionEntryGroup" targetId="8f77-0290-5b40-2a4c">
+              <constraints>
+                <constraint type="min" value="2" field="selections" scope="parent" shared="true" id="8303-8b4f-7346-129b"/>
+                <constraint type="max" value="3" field="selections" scope="parent" shared="true" id="d846-5de1-e004-b09b"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Other Powers" hidden="false" id="eead-c371-f21a-2f35" type="selectionEntryGroup" targetId="d187-4aa6-4f21-7b77"/>
+          </entryLinks>
           <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f4dd-8efc-35c9-08a6" type="max"/>
+            <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="1f20-f54e-03d3-738e"/>
           </constraints>
           <infoLinks>
-            <infoLink id="cd94-5b3e-34b2-811a" name="Power Activation (First Mate)" hidden="false" targetId="6819-fdeb-c82b-4b42" type="rule"/>
+            <infoLink name="Power Activation (First Mate)" id="1d9b-1360-4391-68b7" hidden="false" type="rule" targetId="6819-fdeb-c82b-4b42"/>
           </infoLinks>
-        </entryLink>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
         <entryLink id="6a9a-a013-185e-a1b7" name="Equipment" hidden="false" collective="false" import="true" targetId="270a-a5c0-3695-1fe4" type="selectionEntryGroup">
           <constraints>
-            <constraint field="ef24-ff59-caa4-b0e8" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d88a-e873-b1bc-d14e" type="max"/>
+            <constraint field="ef24-ff59-caa4-b0e8" scope="parent" value="5" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d88a-e873-b1bc-d14e" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="43e1-36ec-98da-6818" name="Level" hidden="false" collective="false" import="true" targetId="4cd1-ff48-5eaf-e868" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6199-8f8e-c0fe-38ea" name="First Mate Rogue" hidden="false" collective="false" import="true" type="model">
@@ -1486,34 +1603,34 @@
           <modifiers>
             <modifier type="increment" field="dc65-e78a-d390-d9d5" value="1">
               <conditions>
-                <condition field="selections" scope="6199-8f8e-c0fe-38ea" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a894-0013-4e76-3d68" type="notEqualTo"/>
+                <condition field="selections" scope="6199-8f8e-c0fe-38ea" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a894-0013-4e76-3d68" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="453a-8ce6-f448-bb37" value="+3">
               <conditions>
-                <condition field="selections" scope="6199-8f8e-c0fe-38ea" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3666-82f5-e5cd-0e6b" type="notEqualTo"/>
+                <condition field="selections" scope="6199-8f8e-c0fe-38ea" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3666-82f5-e5cd-0e6b" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="d603-9472-1d68-663e" value="+3">
               <conditions>
-                <condition field="selections" scope="6199-8f8e-c0fe-38ea" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c40d-38e2-2da5-e730" type="notEqualTo"/>
+                <condition field="selections" scope="6199-8f8e-c0fe-38ea" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c40d-38e2-2da5-e730" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="1">
               <conditions>
-                <condition field="selections" scope="6199-8f8e-c0fe-38ea" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c5f-174f-fa1f-26c7" type="greaterThan"/>
+                <condition field="selections" scope="6199-8f8e-c0fe-38ea" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c5f-174f-fa1f-26c7" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="4">
               <conditions>
-                <condition field="selections" scope="6199-8f8e-c0fe-38ea" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea4f-6372-4af1-e30b" type="greaterThan"/>
+                <condition field="selections" scope="6199-8f8e-c0fe-38ea" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea4f-6372-4af1-e30b" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <modifierGroups>
             <modifierGroup>
               <conditions>
-                <condition field="selections" scope="6199-8f8e-c0fe-38ea" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b824-fc04-4c55-b49e" type="greaterThan"/>
+                <condition field="selections" scope="6199-8f8e-c0fe-38ea" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b824-fc04-4c55-b49e" type="greaterThan"/>
               </conditions>
               <modifiers>
                 <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="2"/>
@@ -1533,65 +1650,74 @@
       </profiles>
       <categoryLinks>
         <categoryLink id="e919-91a0-b518-518c" name="Faction: Stargrave Crew" hidden="false" targetId="7011-8c8a-78f8-283e" primary="false"/>
-        <categoryLink id="ad69-c071-227f-636a" name="New CategoryLink" hidden="false" targetId="8749-37ea-6f9e-0824" primary="true"/>
+        <categoryLink id="ad69-c071-227f-636a" name="First Mate" hidden="false" targetId="8749-37ea-6f9e-0824" primary="true"/>
         <categoryLink id="ff15-8195-0742-b48c" name="Core Rogue" hidden="false" targetId="8e49-f5d3-e9cd-c200" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="b7e8-7db1-b702-043b" name="Background" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd5f-5dc9-2d60-72dc" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a88-4bc2-3978-2abd" type="max"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd5f-5dc9-2d60-72dc" type="min"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a88-4bc2-3978-2abd" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="a894-0013-4e76-3d68" name="+1 Move" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa8b-86c3-f1ec-3a5a" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa8b-86c3-f1ec-3a5a" type="max"/>
               </constraints>
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3666-82f5-e5cd-0e6b" name="+1 Fight" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7578-14e0-ff5f-0b5a" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7578-14e0-ff5f-0b5a" type="max"/>
               </constraints>
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c40d-38e2-2da5-e730" name="+1 Shoot" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cdfe-3904-0a9f-39b3" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cdfe-3904-0a9f-39b3" type="max"/>
               </constraints>
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="be92-0975-2c56-5495" name="Powers" hidden="false" collective="false" import="true" targetId="7753-4141-f613-ae54" type="selectionEntryGroup">
+        <selectionEntryGroup name="Powers" id="fef8-0834-8140-2969" hidden="false">
+          <entryLinks>
+            <entryLink import="true" name="Core Powers" hidden="false" id="ade9-5511-c784-2d49" type="selectionEntryGroup" targetId="8f77-0290-5b40-2a4c">
+              <constraints>
+                <constraint type="min" value="2" field="selections" scope="parent" shared="true" id="2929-ee04-1a4b-4ef1"/>
+                <constraint type="max" value="3" field="selections" scope="parent" shared="true" id="d578-968a-2baa-a77d"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Other Powers" hidden="false" id="b627-40e8-6344-3366" type="selectionEntryGroup" targetId="d187-4aa6-4f21-7b77"/>
+          </entryLinks>
           <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3e94-3795-1123-e76e" type="max"/>
+            <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="224b-943a-a03b-0e0c"/>
           </constraints>
           <infoLinks>
-            <infoLink id="18f4-d14c-b14b-d867" name="Power Activation (First Mate)" hidden="false" targetId="6819-fdeb-c82b-4b42" type="rule"/>
+            <infoLink name="Power Activation (First Mate)" id="3153-7531-504d-6b31" hidden="false" type="rule" targetId="6819-fdeb-c82b-4b42"/>
           </infoLinks>
-        </entryLink>
-        <entryLink id="a5eb-faa4-143d-546a" name="Gears" hidden="false" collective="false" import="true" targetId="270a-a5c0-3695-1fe4" type="selectionEntryGroup">
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="a5eb-faa4-143d-546a" name="Equipment" hidden="false" collective="false" import="true" targetId="270a-a5c0-3695-1fe4" type="selectionEntryGroup">
           <constraints>
-            <constraint field="ef24-ff59-caa4-b0e8" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="664c-ddb5-3dbc-bc4b" type="max"/>
+            <constraint field="ef24-ff59-caa4-b0e8" scope="parent" value="5" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="664c-ddb5-3dbc-bc4b" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="6456-6895-ed60-15e2" name="Level" hidden="false" collective="false" import="true" targetId="4cd1-ff48-5eaf-e868" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ce96-23fc-e0b7-e3e8" name="First Mate Tekker" hidden="false" collective="false" import="true" type="model">
@@ -1600,39 +1726,39 @@
           <modifiers>
             <modifier type="increment" field="c25e-02c0-2580-ff3c" value="1">
               <conditions>
-                <condition field="selections" scope="ce96-23fc-e0b7-e3e8" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="449a-2a69-7e11-59e2" type="notEqualTo"/>
+                <condition field="selections" scope="ce96-23fc-e0b7-e3e8" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="449a-2a69-7e11-59e2" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="d603-9472-1d68-663e" value="+3">
               <conditions>
-                <condition field="selections" scope="ce96-23fc-e0b7-e3e8" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3ce8-551c-625b-45f6" type="notEqualTo"/>
+                <condition field="selections" scope="ce96-23fc-e0b7-e3e8" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3ce8-551c-625b-45f6" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="dc65-e78a-d390-d9d5" value="1">
               <conditions>
-                <condition field="selections" scope="ce96-23fc-e0b7-e3e8" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d804-c388-e30a-ea77" type="notEqualTo"/>
+                <condition field="selections" scope="ce96-23fc-e0b7-e3e8" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d804-c388-e30a-ea77" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="453a-8ce6-f448-bb37" value="+3">
               <conditions>
-                <condition field="selections" scope="ce96-23fc-e0b7-e3e8" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3ce8-551c-625b-45f6" type="notEqualTo"/>
+                <condition field="selections" scope="ce96-23fc-e0b7-e3e8" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3ce8-551c-625b-45f6" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="4">
               <conditions>
-                <condition field="selections" scope="ce96-23fc-e0b7-e3e8" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea4f-6372-4af1-e30b" type="greaterThan"/>
+                <condition field="selections" scope="ce96-23fc-e0b7-e3e8" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea4f-6372-4af1-e30b" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="1">
               <conditions>
-                <condition field="selections" scope="ce96-23fc-e0b7-e3e8" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c5f-174f-fa1f-26c7" type="greaterThan"/>
+                <condition field="selections" scope="ce96-23fc-e0b7-e3e8" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c5f-174f-fa1f-26c7" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <modifierGroups>
             <modifierGroup>
               <conditions>
-                <condition field="selections" scope="ce96-23fc-e0b7-e3e8" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b824-fc04-4c55-b49e" type="greaterThan"/>
+                <condition field="selections" scope="ce96-23fc-e0b7-e3e8" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b824-fc04-4c55-b49e" type="greaterThan"/>
               </conditions>
               <modifiers>
                 <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="2"/>
@@ -1652,74 +1778,83 @@
       </profiles>
       <categoryLinks>
         <categoryLink id="d517-3aba-473d-2aa0" name="Faction: Stargrave Crew" hidden="false" targetId="7011-8c8a-78f8-283e" primary="false"/>
-        <categoryLink id="cbde-364b-fc1f-824f" name="New CategoryLink" hidden="false" targetId="8749-37ea-6f9e-0824" primary="true"/>
+        <categoryLink id="cbde-364b-fc1f-824f" name="First Mate" hidden="false" targetId="8749-37ea-6f9e-0824" primary="true"/>
         <categoryLink id="cb7e-d608-5078-993c" name="Core Tekker" hidden="false" targetId="8702-3db8-4e88-faf8" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="7236-e2bc-4650-0565" name="Background" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2ef-620e-e970-307c" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0abc-2eee-e799-4c1b" type="max"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2ef-620e-e970-307c" type="min"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0abc-2eee-e799-4c1b" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="d804-c388-e30a-ea77" name="+1 Move" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be4e-459e-047e-1d28" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be4e-459e-047e-1d28" type="max"/>
               </constraints>
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3aea-f295-c83e-8864" name="+1 Fight" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="34db-5acc-f96b-28e3" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="34db-5acc-f96b-28e3" type="max"/>
               </constraints>
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3ce8-551c-625b-45f6" name="+1 Shoot" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="19e7-286b-fef5-c321" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="19e7-286b-fef5-c321" type="max"/>
               </constraints>
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="449a-2a69-7e11-59e2" name="+1 Health" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f9b-776c-4d14-0719" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f9b-776c-4d14-0719" type="max"/>
               </constraints>
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="7793-2ce4-ebd5-de62" name="Powers" hidden="false" collective="false" import="true" targetId="7753-4141-f613-ae54" type="selectionEntryGroup">
+        <selectionEntryGroup name="Powers" id="13f2-8008-1a4d-667c" hidden="false">
+          <entryLinks>
+            <entryLink import="true" name="Core Powers" hidden="false" id="de89-38b6-638e-3bc4" type="selectionEntryGroup" targetId="8f77-0290-5b40-2a4c">
+              <constraints>
+                <constraint type="min" value="2" field="selections" scope="parent" shared="true" id="64d1-79b1-8e2c-3549"/>
+                <constraint type="max" value="3" field="selections" scope="parent" shared="true" id="8a34-db5c-a7d2-7576"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Other Powers" hidden="false" id="2211-d867-b98a-182b" type="selectionEntryGroup" targetId="d187-4aa6-4f21-7b77"/>
+          </entryLinks>
           <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="20a3-b771-3cd2-ff55" type="max"/>
+            <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="f8cc-7bc4-7d83-bdec"/>
           </constraints>
           <infoLinks>
-            <infoLink id="1189-c2a6-cab3-6e22" name="Power Activation (First Mate)" hidden="false" targetId="6819-fdeb-c82b-4b42" type="rule"/>
+            <infoLink name="Power Activation (First Mate)" id="3c7e-a778-e568-e32b" hidden="false" type="rule" targetId="6819-fdeb-c82b-4b42"/>
           </infoLinks>
-        </entryLink>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
         <entryLink id="5555-1b0a-c82f-ffeb" name="Equipment" hidden="false" collective="false" import="true" targetId="270a-a5c0-3695-1fe4" type="selectionEntryGroup">
           <constraints>
-            <constraint field="ef24-ff59-caa4-b0e8" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="aca7-5d58-60ef-940b" type="max"/>
+            <constraint field="ef24-ff59-caa4-b0e8" scope="parent" value="5" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="aca7-5d58-60ef-940b" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="9312-50da-4f61-0e54" name="Level" hidden="false" collective="false" import="true" targetId="4cd1-ff48-5eaf-e868" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4bea-2bb5-2b58-e0fd" name="First Mate Veteran" hidden="false" collective="false" import="true" type="model">
@@ -1728,34 +1863,34 @@
           <modifiers>
             <modifier type="set" field="d603-9472-1d68-663e" value="+3">
               <conditions>
-                <condition field="selections" scope="4bea-2bb5-2b58-e0fd" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1bc1-840a-ddf7-e61e" type="notEqualTo"/>
+                <condition field="selections" scope="4bea-2bb5-2b58-e0fd" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1bc1-840a-ddf7-e61e" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="453a-8ce6-f448-bb37" value="+4">
               <conditions>
-                <condition field="selections" scope="4bea-2bb5-2b58-e0fd" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e1f3-5290-6b92-2d55" type="notEqualTo"/>
+                <condition field="selections" scope="4bea-2bb5-2b58-e0fd" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e1f3-5290-6b92-2d55" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="dc65-e78a-d390-d9d5" value="1">
               <conditions>
-                <condition field="selections" scope="4bea-2bb5-2b58-e0fd" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e1a3-8ae5-9aed-baf7" type="notEqualTo"/>
+                <condition field="selections" scope="4bea-2bb5-2b58-e0fd" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e1a3-8ae5-9aed-baf7" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="1">
               <conditions>
-                <condition field="selections" scope="4bea-2bb5-2b58-e0fd" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c5f-174f-fa1f-26c7" type="greaterThan"/>
+                <condition field="selections" scope="4bea-2bb5-2b58-e0fd" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c5f-174f-fa1f-26c7" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="4">
               <conditions>
-                <condition field="selections" scope="4bea-2bb5-2b58-e0fd" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea4f-6372-4af1-e30b" type="greaterThan"/>
+                <condition field="selections" scope="4bea-2bb5-2b58-e0fd" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea4f-6372-4af1-e30b" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <modifierGroups>
             <modifierGroup>
               <conditions>
-                <condition field="selections" scope="4bea-2bb5-2b58-e0fd" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b824-fc04-4c55-b49e" type="greaterThan"/>
+                <condition field="selections" scope="4bea-2bb5-2b58-e0fd" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b824-fc04-4c55-b49e" type="greaterThan"/>
               </conditions>
               <modifiers>
                 <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="2"/>
@@ -1775,56 +1910,65 @@
       </profiles>
       <categoryLinks>
         <categoryLink id="d8c3-5c9f-5268-ce7c" name="Faction: Stargrave Crew" hidden="false" targetId="7011-8c8a-78f8-283e" primary="false"/>
-        <categoryLink id="dfdd-53dc-d756-4f70" name="New CategoryLink" hidden="false" targetId="8749-37ea-6f9e-0824" primary="true"/>
+        <categoryLink id="dfdd-53dc-d756-4f70" name="First Mate" hidden="false" targetId="8749-37ea-6f9e-0824" primary="true"/>
         <categoryLink id="581c-34ec-897b-7e5e" name="Core Veteran" hidden="false" targetId="1510-fec4-0334-8026" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="77c5-657f-fb5d-39c6" name="Background" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a5f-bebf-f56f-af0d" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8666-49be-e04c-57c2" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a5f-bebf-f56f-af0d" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8666-49be-e04c-57c2" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="e1a3-8ae5-9aed-baf7" name="+1 Move" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e1f3-5290-6b92-2d55" name="+1 Fight" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1bc1-840a-ddf7-e61e" name="+1 Shoot" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="31bb-a5ea-2362-9f01" name="Powers" hidden="false" collective="false" import="true" targetId="7753-4141-f613-ae54" type="selectionEntryGroup">
+        <selectionEntryGroup name="Powers" id="80c2-b44e-cc7b-c78b" hidden="false">
+          <entryLinks>
+            <entryLink import="true" name="Core Powers" hidden="false" id="2113-06aa-6617-aa22" type="selectionEntryGroup" targetId="8f77-0290-5b40-2a4c">
+              <constraints>
+                <constraint type="min" value="2" field="selections" scope="parent" shared="true" id="f2ee-f16c-b0aa-b41c"/>
+                <constraint type="max" value="3" field="selections" scope="parent" shared="true" id="122d-76df-284d-2863"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Other Powers" hidden="false" id="2aef-b5e6-5670-1d30" type="selectionEntryGroup" targetId="d187-4aa6-4f21-7b77"/>
+          </entryLinks>
           <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a4e6-2ea1-038f-b35d" type="max"/>
+            <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="0b78-86a2-9e68-7e57"/>
           </constraints>
           <infoLinks>
-            <infoLink id="d190-57ad-d99d-41fb" name="Power Activation (First Mate)" hidden="false" targetId="6819-fdeb-c82b-4b42" type="rule"/>
+            <infoLink name="Power Activation (First Mate)" id="90e9-fc72-576b-21bf" hidden="false" type="rule" targetId="6819-fdeb-c82b-4b42"/>
           </infoLinks>
-        </entryLink>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
         <entryLink id="bb3e-0b53-d99d-6ae2" name="Equipment" hidden="false" collective="false" import="true" targetId="270a-a5c0-3695-1fe4" type="selectionEntryGroup">
           <constraints>
-            <constraint field="ef24-ff59-caa4-b0e8" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4e5b-2f66-c8a4-9465" type="max"/>
+            <constraint field="ef24-ff59-caa4-b0e8" scope="parent" value="5" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4e5b-2f66-c8a4-9465" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="525b-c257-558e-7219" name="Level" hidden="false" collective="false" import="true" targetId="4cd1-ff48-5eaf-e868" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7a22-0242-d676-099d" name="Aristocrat" hidden="false" collective="false" import="true" type="upgrade">
@@ -1833,39 +1977,39 @@
           <modifiers>
             <modifier type="set" field="cd10-7835-de9f-ba64" value="+5">
               <conditions>
-                <condition field="selections" scope="7a22-0242-d676-099d" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f877-56c0-4518-cf9d" type="notEqualTo"/>
+                <condition field="selections" scope="7a22-0242-d676-099d" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f877-56c0-4518-cf9d" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="c25e-02c0-2580-ff3c" value="1">
               <conditions>
-                <condition field="selections" scope="7a22-0242-d676-099d" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b8f4-8238-f5bc-99e5" type="notEqualTo"/>
+                <condition field="selections" scope="7a22-0242-d676-099d" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b8f4-8238-f5bc-99e5" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="453a-8ce6-f448-bb37" value="+4">
               <conditions>
-                <condition field="selections" scope="7a22-0242-d676-099d" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b390-35e9-b308-4727" type="notEqualTo"/>
+                <condition field="selections" scope="7a22-0242-d676-099d" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b390-35e9-b308-4727" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="d603-9472-1d68-663e" value="+3">
               <conditions>
-                <condition field="selections" scope="7a22-0242-d676-099d" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5ac2-64e0-6cb3-c93d" type="notEqualTo"/>
+                <condition field="selections" scope="7a22-0242-d676-099d" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5ac2-64e0-6cb3-c93d" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="1">
               <conditions>
-                <condition field="selections" scope="7a22-0242-d676-099d" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c5f-174f-fa1f-26c7" type="greaterThan"/>
+                <condition field="selections" scope="7a22-0242-d676-099d" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c5f-174f-fa1f-26c7" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="4">
               <conditions>
-                <condition field="selections" scope="7a22-0242-d676-099d" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea4f-6372-4af1-e30b" type="greaterThan"/>
+                <condition field="selections" scope="7a22-0242-d676-099d" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea4f-6372-4af1-e30b" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <modifierGroups>
             <modifierGroup>
               <conditions>
-                <condition field="selections" scope="7a22-0242-d676-099d" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b824-fc04-4c55-b49e" type="greaterThan"/>
+                <condition field="selections" scope="7a22-0242-d676-099d" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b824-fc04-4c55-b49e" type="greaterThan"/>
               </conditions>
               <modifiers>
                 <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="2"/>
@@ -1891,56 +2035,65 @@
       <selectionEntryGroups>
         <selectionEntryGroup id="14b3-60ba-6ab9-c8c8" name="Background" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e52-c874-66de-0207" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="315f-874c-8de0-09b1" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e52-c874-66de-0207" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="315f-874c-8de0-09b1" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="f877-56c0-4518-cf9d" name="+1 Will" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b8f4-8238-f5bc-99e5" name="+1 Health" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b390-35e9-b308-4727" name="+1 Fight" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5ac2-64e0-6cb3-c93d" name="+1 Shoot" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup name="Powers" id="7b84-75d8-ccce-c143" hidden="false">
+          <entryLinks>
+            <entryLink import="true" name="Core Powers" hidden="false" id="605f-d87c-3819-f7e2" type="selectionEntryGroup" targetId="8f77-0290-5b40-2a4c">
+              <constraints>
+                <constraint type="min" value="3" field="selections" scope="parent" shared="true" id="ca95-8f13-03cb-b165"/>
+                <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="6119-227e-155f-af8d"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Other Powers" hidden="false" id="e43c-564e-7172-a4fc" type="selectionEntryGroup" targetId="d187-4aa6-4f21-7b77"/>
+          </entryLinks>
+          <constraints>
+            <constraint type="max" value="5" field="selections" scope="parent" shared="true" id="f99b-2942-6bc1-bed3"/>
+          </constraints>
+          <infoLinks>
+            <infoLink name="Power Activation (Captain)" id="9103-5690-9b1f-c790" hidden="false" type="rule" targetId="b036-a7e7-db3f-d23b"/>
+          </infoLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="b153-02cb-9b3d-4469" name="Level" hidden="false" collective="false" import="true" targetId="4cd1-ff48-5eaf-e868" type="selectionEntry"/>
         <entryLink id="dfc1-f355-67e5-263e" name="Equipment" hidden="false" collective="false" import="true" targetId="270a-a5c0-3695-1fe4" type="selectionEntryGroup">
           <constraints>
-            <constraint field="ef24-ff59-caa4-b0e8" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d884-4314-0c5e-1748" type="max"/>
+            <constraint field="ef24-ff59-caa4-b0e8" scope="parent" value="6" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d884-4314-0c5e-1748" type="max"/>
           </constraints>
-        </entryLink>
-        <entryLink id="10dc-9cfd-8dcf-b2f5" name="Powers" hidden="false" collective="false" import="true" targetId="7753-4141-f613-ae54" type="selectionEntryGroup">
-          <constraints>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="37e0-0ee3-3bf4-5b7f" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="8920-830a-36e7-4900" name="Power Activation (Captain)" hidden="false" targetId="b036-a7e7-db3f-d23b" type="rule"/>
-          </infoLinks>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ce42-d959-4381-2b64" name="Hunter" hidden="false" collective="false" import="true" type="upgrade">
@@ -1949,34 +2102,34 @@
           <modifiers>
             <modifier type="increment" field="dc65-e78a-d390-d9d5" value="1">
               <conditions>
-                <condition field="selections" scope="ce42-d959-4381-2b64" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="956b-c4f1-9590-03c2" type="notEqualTo"/>
+                <condition field="selections" scope="ce42-d959-4381-2b64" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="956b-c4f1-9590-03c2" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="453a-8ce6-f448-bb37" value="+4">
               <conditions>
-                <condition field="selections" scope="ce42-d959-4381-2b64" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fcd5-d8ed-7f06-a2d4" type="notEqualTo"/>
+                <condition field="selections" scope="ce42-d959-4381-2b64" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fcd5-d8ed-7f06-a2d4" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="d603-9472-1d68-663e" value="+4">
               <conditions>
-                <condition field="selections" scope="ce42-d959-4381-2b64" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ab75-526f-2f8b-a001" type="notEqualTo"/>
+                <condition field="selections" scope="ce42-d959-4381-2b64" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ab75-526f-2f8b-a001" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="1">
               <conditions>
-                <condition field="selections" scope="ce42-d959-4381-2b64" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c5f-174f-fa1f-26c7" type="greaterThan"/>
+                <condition field="selections" scope="ce42-d959-4381-2b64" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c5f-174f-fa1f-26c7" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="4">
               <conditions>
-                <condition field="selections" scope="ce42-d959-4381-2b64" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea4f-6372-4af1-e30b" type="greaterThan"/>
+                <condition field="selections" scope="ce42-d959-4381-2b64" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea4f-6372-4af1-e30b" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <modifierGroups>
             <modifierGroup>
               <conditions>
-                <condition field="selections" scope="ce42-d959-4381-2b64" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b824-fc04-4c55-b49e" type="greaterThan"/>
+                <condition field="selections" scope="ce42-d959-4381-2b64" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b824-fc04-4c55-b49e" type="greaterThan"/>
               </conditions>
               <modifiers>
                 <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="2"/>
@@ -2002,50 +2155,59 @@
       <selectionEntryGroups>
         <selectionEntryGroup id="8377-b9f8-4b83-77f5" name="Background" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2949-dd70-be76-257f" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a7f2-4281-2854-54ec" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2949-dd70-be76-257f" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a7f2-4281-2854-54ec" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="956b-c4f1-9590-03c2" name="+1 Move" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fcd5-d8ed-7f06-a2d4" name="+1 Fight" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ab75-526f-2f8b-a001" name="+1 Shoot" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup name="Powers" id="1796-b9fb-61ba-c47a" hidden="false">
+          <entryLinks>
+            <entryLink import="true" name="Core Powers" hidden="false" id="2aba-7a7d-702d-4477" type="selectionEntryGroup" targetId="8f77-0290-5b40-2a4c">
+              <constraints>
+                <constraint type="min" value="3" field="selections" scope="parent" shared="true" id="d30c-19b0-8433-6fde"/>
+                <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="ab25-d4bb-5d85-3d51"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Other Powers" hidden="false" id="c6ce-d8a8-f0f5-396c" type="selectionEntryGroup" targetId="d187-4aa6-4f21-7b77"/>
+          </entryLinks>
+          <constraints>
+            <constraint type="max" value="5" field="selections" scope="parent" shared="true" id="c6b2-8f0d-ec3e-b103"/>
+          </constraints>
+          <infoLinks>
+            <infoLink name="Power Activation (Captain)" id="4a1e-28d3-e4d2-97d9" hidden="false" type="rule" targetId="b036-a7e7-db3f-d23b"/>
+          </infoLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="ce31-bc9b-ee84-3554" name="Level" hidden="false" collective="false" import="true" targetId="4cd1-ff48-5eaf-e868" type="selectionEntry"/>
         <entryLink id="aa56-eedb-5d2a-e85e" name="Equipment" hidden="false" collective="false" import="true" targetId="270a-a5c0-3695-1fe4" type="selectionEntryGroup">
           <constraints>
-            <constraint field="ef24-ff59-caa4-b0e8" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f94-b31a-a389-6431" type="max"/>
+            <constraint field="ef24-ff59-caa4-b0e8" scope="parent" value="6" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f94-b31a-a389-6431" type="max"/>
           </constraints>
-        </entryLink>
-        <entryLink id="d0fe-a739-f172-ac58" name="Powers" hidden="false" collective="false" import="true" targetId="7753-4141-f613-ae54" type="selectionEntryGroup">
-          <constraints>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1283-0d4d-d6ce-e599" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="2490-ffc9-acb1-f079" name="Power Activation (Captain)" hidden="false" targetId="b036-a7e7-db3f-d23b" type="rule"/>
-          </infoLinks>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6a4f-b533-4675-9384" name="First Mate Aristocrat" hidden="false" collective="false" import="true" type="upgrade">
@@ -2054,39 +2216,39 @@
           <modifiers>
             <modifier type="set" field="cd10-7835-de9f-ba64" value="+4">
               <conditions>
-                <condition field="selections" scope="6a4f-b533-4675-9384" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ba84-0b26-66eb-ccac" type="notEqualTo"/>
+                <condition field="selections" scope="6a4f-b533-4675-9384" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ba84-0b26-66eb-ccac" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="c25e-02c0-2580-ff3c" value="1">
               <conditions>
-                <condition field="selections" scope="6a4f-b533-4675-9384" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1318-9b12-720f-c67e" type="notEqualTo"/>
+                <condition field="selections" scope="6a4f-b533-4675-9384" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1318-9b12-720f-c67e" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="453a-8ce6-f448-bb37" value="+3">
               <conditions>
-                <condition field="selections" scope="6a4f-b533-4675-9384" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4aeb-6e42-903a-b33b" type="notEqualTo"/>
+                <condition field="selections" scope="6a4f-b533-4675-9384" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4aeb-6e42-903a-b33b" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="d603-9472-1d68-663e" value="+3">
               <conditions>
-                <condition field="selections" scope="6a4f-b533-4675-9384" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="224e-3c6a-95f3-c08c" type="notEqualTo"/>
+                <condition field="selections" scope="6a4f-b533-4675-9384" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="224e-3c6a-95f3-c08c" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="1">
               <conditions>
-                <condition field="selections" scope="6a4f-b533-4675-9384" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c5f-174f-fa1f-26c7" type="greaterThan"/>
+                <condition field="selections" scope="6a4f-b533-4675-9384" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c5f-174f-fa1f-26c7" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="4">
               <conditions>
-                <condition field="selections" scope="6a4f-b533-4675-9384" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea4f-6372-4af1-e30b" type="greaterThan"/>
+                <condition field="selections" scope="6a4f-b533-4675-9384" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea4f-6372-4af1-e30b" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <modifierGroups>
             <modifierGroup>
               <conditions>
-                <condition field="selections" scope="6a4f-b533-4675-9384" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b824-fc04-4c55-b49e" type="greaterThan"/>
+                <condition field="selections" scope="6a4f-b533-4675-9384" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b824-fc04-4c55-b49e" type="greaterThan"/>
               </conditions>
               <modifiers>
                 <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="2"/>
@@ -2112,56 +2274,65 @@
       <selectionEntryGroups>
         <selectionEntryGroup id="b97a-8f25-7930-4f69" name="Background" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="93eb-04ab-d4f1-a6f2" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1655-fd0e-3a45-1f3a" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="93eb-04ab-d4f1-a6f2" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1655-fd0e-3a45-1f3a" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="1318-9b12-720f-c67e" name="+1 Health" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ba84-0b26-66eb-ccac" name="+1 Will" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4aeb-6e42-903a-b33b" name="+1 Fight" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="224e-3c6a-95f3-c08c" name="+1 Shoot" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup name="Powers" id="507c-9712-2da5-07f4" hidden="false">
+          <entryLinks>
+            <entryLink import="true" name="Core Powers" hidden="false" id="bc68-b642-1164-6d53" type="selectionEntryGroup" targetId="8f77-0290-5b40-2a4c">
+              <constraints>
+                <constraint type="min" value="2" field="selections" scope="parent" shared="true" id="36a3-fc76-bec3-c948"/>
+                <constraint type="max" value="3" field="selections" scope="parent" shared="true" id="6060-13e5-22d6-24c7"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Other Powers" hidden="false" id="8dc7-d12d-3b90-9974" type="selectionEntryGroup" targetId="d187-4aa6-4f21-7b77"/>
+          </entryLinks>
+          <constraints>
+            <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="9b46-22c3-41f7-9ebe"/>
+          </constraints>
+          <infoLinks>
+            <infoLink name="Power Activation (First Mate)" id="2023-c83a-6fb2-8004" hidden="false" type="rule" targetId="6819-fdeb-c82b-4b42"/>
+          </infoLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="1c9f-8093-0d83-196a" name="Level" hidden="false" collective="false" import="true" targetId="4cd1-ff48-5eaf-e868" type="selectionEntry"/>
         <entryLink id="f913-414b-cee4-677d" name="Equipment" hidden="false" collective="false" import="true" targetId="270a-a5c0-3695-1fe4" type="selectionEntryGroup">
           <constraints>
-            <constraint field="ef24-ff59-caa4-b0e8" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe10-c5df-82c5-d490" type="max"/>
+            <constraint field="ef24-ff59-caa4-b0e8" scope="parent" value="5" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe10-c5df-82c5-d490" type="max"/>
           </constraints>
-        </entryLink>
-        <entryLink id="c619-8674-5002-7fe0" name="Powers" hidden="false" collective="false" import="true" targetId="7753-4141-f613-ae54" type="selectionEntryGroup">
-          <constraints>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="affd-8147-c314-3ed6" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="cb37-0409-b434-569c" name="Power Activation (First Mate)" hidden="false" targetId="6819-fdeb-c82b-4b42" type="rule"/>
-          </infoLinks>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3c45-0df7-b87f-09d0" name="First Mate Hunter" hidden="false" collective="false" import="true" type="upgrade">
@@ -2170,34 +2341,34 @@
           <modifiers>
             <modifier type="set" field="453a-8ce6-f448-bb37" value="+3">
               <conditions>
-                <condition field="selections" scope="3c45-0df7-b87f-09d0" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f2f5-6d74-4923-eba4" type="notEqualTo"/>
+                <condition field="selections" scope="3c45-0df7-b87f-09d0" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f2f5-6d74-4923-eba4" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="d603-9472-1d68-663e" value="+4">
               <conditions>
-                <condition field="selections" scope="3c45-0df7-b87f-09d0" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="88a8-cfd8-c35c-62e2" type="notEqualTo"/>
+                <condition field="selections" scope="3c45-0df7-b87f-09d0" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="88a8-cfd8-c35c-62e2" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="dc65-e78a-d390-d9d5" value="1">
               <conditions>
-                <condition field="selections" scope="3c45-0df7-b87f-09d0" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7986-5bb6-a326-d6af" type="notEqualTo"/>
+                <condition field="selections" scope="3c45-0df7-b87f-09d0" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7986-5bb6-a326-d6af" type="notEqualTo"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="1">
               <conditions>
-                <condition field="selections" scope="3c45-0df7-b87f-09d0" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c5f-174f-fa1f-26c7" type="greaterThan"/>
+                <condition field="selections" scope="3c45-0df7-b87f-09d0" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c5f-174f-fa1f-26c7" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="4">
               <conditions>
-                <condition field="selections" scope="3c45-0df7-b87f-09d0" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea4f-6372-4af1-e30b" type="greaterThan"/>
+                <condition field="selections" scope="3c45-0df7-b87f-09d0" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea4f-6372-4af1-e30b" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <modifierGroups>
             <modifierGroup>
               <conditions>
-                <condition field="selections" scope="3c45-0df7-b87f-09d0" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b824-fc04-4c55-b49e" type="greaterThan"/>
+                <condition field="selections" scope="3c45-0df7-b87f-09d0" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b824-fc04-4c55-b49e" type="greaterThan"/>
               </conditions>
               <modifiers>
                 <modifier type="increment" field="d1a5-3245-2f90-1ffe" value="2"/>
@@ -2223,50 +2394,59 @@
       <selectionEntryGroups>
         <selectionEntryGroup id="3ddc-a86b-f293-4aad" name="Background" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0324-3b11-46d1-e2d3" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fcdb-67cc-123f-703c" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0324-3b11-46d1-e2d3" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fcdb-67cc-123f-703c" type="min"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="7986-5bb6-a326-d6af" name="+1 Move" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f2f5-6d74-4923-eba4" name="+1 Fight" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="88a8-cfd8-c35c-62e2" name="+1 Shoot" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
-                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+                <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="e3e2-c9f9-bad9-c593" name="Gears" hidden="false" collective="false" import="true" targetId="270a-a5c0-3695-1fe4" type="selectionEntryGroup">
+        <selectionEntryGroup name="Powers" id="a184-bf55-7cbc-48b2" hidden="false">
+          <entryLinks>
+            <entryLink import="true" name="Core Powers" hidden="false" id="81d8-01ed-7ad8-a892" type="selectionEntryGroup" targetId="8f77-0290-5b40-2a4c">
+              <constraints>
+                <constraint type="min" value="2" field="selections" scope="parent" shared="true" id="2ea5-58f5-741a-56b4"/>
+                <constraint type="max" value="3" field="selections" scope="parent" shared="true" id="d954-e55a-953c-08d5"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Other Powers" hidden="false" id="e3e8-361d-c70a-2212" type="selectionEntryGroup" targetId="d187-4aa6-4f21-7b77"/>
+          </entryLinks>
           <constraints>
-            <constraint field="ef24-ff59-caa4-b0e8" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c5c3-0cb9-e908-bbee" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="c6ce-5577-2b0e-62f1" name="Powers" hidden="false" collective="false" import="true" targetId="7753-4141-f613-ae54" type="selectionEntryGroup">
-          <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="51fc-f847-2434-f191" type="max"/>
+            <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="7bf0-2cba-4899-80f9"/>
           </constraints>
           <infoLinks>
-            <infoLink id="7c9a-ee38-f1ab-35c8" name="Power Activation (First Mate)" hidden="false" targetId="6819-fdeb-c82b-4b42" type="rule"/>
+            <infoLink name="Power Activation (First Mate)" id="b1e1-9623-4e49-9305" hidden="false" type="rule" targetId="6819-fdeb-c82b-4b42"/>
           </infoLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="e3e2-c9f9-bad9-c593" name="Equipment" hidden="false" collective="false" import="true" targetId="270a-a5c0-3695-1fe4" type="selectionEntryGroup">
+          <constraints>
+            <constraint field="ef24-ff59-caa4-b0e8" scope="parent" value="5" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c5c3-0cb9-e908-bbee" type="max"/>
+          </constraints>
         </entryLink>
         <entryLink id="649b-3add-73d4-1718" name="Level" hidden="false" collective="false" import="true" targetId="4cd1-ff48-5eaf-e868" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
       </costs>
     </selectionEntry>
   </selectionEntries>
@@ -2279,8 +2459,8 @@
       <entryLinks>
         <entryLink id="8d7b-9cac-12fe-783a" name="Combat Armour" hidden="false" collective="false" import="true" targetId="ea4f-6372-4af1-e30b" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe3a-ff88-3488-edba" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3003-ac19-5d14-eb72" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe3a-ff88-3488-edba" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3003-ac19-5d14-eb72" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="3d53-a7dc-2836-65d9" name="Soldier Weapon" hidden="false" collective="false" import="true" targetId="807b-4425-bf96-be3b" type="selectionEntryGroup"/>
@@ -2288,26 +2468,26 @@
     </entryLink>
     <entryLink id="fa10-c128-39ae-9c14" name="Commando" hidden="false" collective="false" import="true" targetId="25d0-2116-83ce-c078" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="c47a-65c7-f596-6b73" name="New CategoryLink" hidden="false" targetId="13f2-16cf-e0bd-6624" primary="true"/>
+        <categoryLink id="c47a-65c7-f596-6b73" name="Specialists" hidden="false" targetId="13f2-16cf-e0bd-6624" primary="true"/>
         <categoryLink id="468d-4abf-762a-f6ed" name="Faction: Stargrave Crew" hidden="false" targetId="7011-8c8a-78f8-283e" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="33ab-01a2-7c6e-80e3" name="Heavy Armour" hidden="false" collective="false" import="true" targetId="b824-fc04-4c55-b49e" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="29d2-b7c6-71e2-2be3" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f0cf-9707-c254-845c" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="29d2-b7c6-71e2-2be3" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f0cf-9707-c254-845c" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="5da7-9b89-ddd9-39c8" name="Grenade (Frag/Smoke)" hidden="false" collective="false" import="true" targetId="ccbe-994d-4323-a5b7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="73f6-e13f-064c-a113" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f54-f5fe-6b3e-ec8b" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="73f6-e13f-064c-a113" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f54-f5fe-6b3e-ec8b" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="6209-c6ac-b39b-9686" name="Hand Weapon" hidden="false" collective="false" import="true" targetId="751f-ebe1-9a04-524e" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b24-b5fd-f4d0-71cf" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="26f2-9dea-8192-d553" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b24-b5fd-f4d0-71cf" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="26f2-9dea-8192-d553" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="75d3-2587-e2dd-d95c" name="Soldier Weapon" hidden="false" collective="false" import="true" targetId="807b-4425-bf96-be3b" type="selectionEntryGroup"/>
@@ -2315,58 +2495,58 @@
     </entryLink>
     <entryLink id="0ae6-4f82-3d3e-c931" name="Burner" hidden="false" collective="false" import="true" targetId="3af1-995d-6a3f-2164" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8e4d-c8a4-4521-2e9e" name="New CategoryLink" hidden="false" targetId="13f2-16cf-e0bd-6624" primary="true"/>
+        <categoryLink id="8e4d-c8a4-4521-2e9e" name="Specialists" hidden="false" targetId="13f2-16cf-e0bd-6624" primary="true"/>
         <categoryLink id="9af8-adf8-ea6e-6729" name="Faction: Stargrave Crew" hidden="false" targetId="7011-8c8a-78f8-283e" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="74cf-8ef3-8d75-c1d1" name="Heavy Armour" hidden="false" collective="false" import="true" targetId="b824-fc04-4c55-b49e" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e95-00bd-cb4a-9c05" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ef9-c25e-529b-ad34" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e95-00bd-cb4a-9c05" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ef9-c25e-529b-ad34" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="f7b5-9c96-3cb5-989c" name="Flamethrower" hidden="false" collective="false" import="true" targetId="4fcb-337a-cabb-7e51" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="166d-ebd0-b5e3-d628" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="41b9-a792-add7-931b" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="166d-ebd0-b5e3-d628" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="41b9-a792-add7-931b" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="d064-bfb2-3252-c0d2" name="Knife" hidden="false" collective="false" import="true" targetId="cb09-0362-58dc-6b9d" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a13c-2de1-6c4d-91b3" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="664d-8a15-8acc-af48" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a13c-2de1-6c4d-91b3" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="664d-8a15-8acc-af48" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="8a57-bc69-7c58-b122" name="Pistol" hidden="false" collective="false" import="true" targetId="4039-8fee-a371-8311" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2edb-2dd6-3be0-0392" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b394-ff5f-7092-0fe2" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2edb-2dd6-3be0-0392" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b394-ff5f-7092-0fe2" type="min"/>
           </constraints>
         </entryLink>
       </entryLinks>
     </entryLink>
     <entryLink id="c0f9-223a-2b7f-eb3a" name="Codebreaker" hidden="false" collective="false" import="true" targetId="aee4-e6c5-e21b-8623" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="a4f6-85d5-3075-3f91" name="New CategoryLink" hidden="false" targetId="13f2-16cf-e0bd-6624" primary="true"/>
+        <categoryLink id="a4f6-85d5-3075-3f91" name="Specialists" hidden="false" targetId="13f2-16cf-e0bd-6624" primary="true"/>
         <categoryLink id="fd6e-a869-c9be-f0e4" name="Faction: Stargrave Crew" hidden="false" targetId="7011-8c8a-78f8-283e" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="b04e-1566-d059-77ac" name="Light Armour" hidden="false" collective="false" import="true" targetId="2c5f-174f-fa1f-26c7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="836f-f252-8ce6-b120" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1cba-32e6-5a85-a0e7" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="836f-f252-8ce6-b120" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1cba-32e6-5a85-a0e7" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="36d2-4a8d-bc3b-a764" name="Deck" hidden="false" collective="false" import="true" targetId="cb72-75b1-00d6-d034" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="51f8-e673-cec9-df0a" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="89be-cbcc-2ccf-e4a9" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="51f8-e673-cec9-df0a" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="89be-cbcc-2ccf-e4a9" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="f98f-78ad-eac0-3589" name="Knife" hidden="false" collective="false" import="true" targetId="cb09-0362-58dc-6b9d" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a04e-6ada-08ed-2881" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac3f-e0bd-e6c2-e8a5" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a04e-6ada-08ed-2881" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac3f-e0bd-e6c2-e8a5" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="d9ce-a1cb-7edf-c13e" name="Soldier Weapon" hidden="false" collective="false" import="true" targetId="807b-4425-bf96-be3b" type="selectionEntryGroup"/>
@@ -2374,26 +2554,26 @@
     </entryLink>
     <entryLink id="56f6-d810-ffb5-e636" name="Casecracker" hidden="false" collective="false" import="true" targetId="fa49-9ab4-5565-f466" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="af65-3254-1e96-be0f" name="New CategoryLink" hidden="false" targetId="13f2-16cf-e0bd-6624" primary="true"/>
+        <categoryLink id="af65-3254-1e96-be0f" name="Specialists" hidden="false" targetId="13f2-16cf-e0bd-6624" primary="true"/>
         <categoryLink id="e952-3fdb-733a-5405" name="Faction: Stargrave Crew" hidden="false" targetId="7011-8c8a-78f8-283e" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="9621-14ff-9d1e-4192" name="Light Armour" hidden="false" collective="false" import="true" targetId="2c5f-174f-fa1f-26c7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9204-0643-bf7a-9bd0" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="59eb-fb80-7948-6834" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9204-0643-bf7a-9bd0" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="59eb-fb80-7948-6834" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="6c89-48ba-fc0c-0501" name="Picks" hidden="false" collective="false" import="true" targetId="84b2-39a3-0985-b603" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c3cd-94bf-d3e2-d1a4" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="38d7-b646-0c59-97dc" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c3cd-94bf-d3e2-d1a4" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="38d7-b646-0c59-97dc" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="d242-4c1c-e904-b6ac" name="Knife" hidden="false" collective="false" import="true" targetId="cb09-0362-58dc-6b9d" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c201-df39-7d50-640d" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0642-e36e-20a9-bd7e" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c201-df39-7d50-640d" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0642-e36e-20a9-bd7e" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="e7b6-6a6d-6daf-e9f0" name="Soldier Weapon" hidden="false" collective="false" import="true" targetId="807b-4425-bf96-be3b" type="selectionEntryGroup"/>
@@ -2401,26 +2581,26 @@
     </entryLink>
     <entryLink id="eeb6-d21a-fdea-690a" name="Pathfinder" hidden="false" collective="false" import="true" targetId="8516-acdf-df6c-426d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="93a2-6ccf-d3f5-6780" name="New CategoryLink" hidden="false" targetId="13f2-16cf-e0bd-6624" primary="true"/>
+        <categoryLink id="93a2-6ccf-d3f5-6780" name="Specialists" hidden="false" targetId="13f2-16cf-e0bd-6624" primary="true"/>
         <categoryLink id="2ccd-cac9-3c1c-9d23" name="Faction: Stargrave Crew" hidden="false" targetId="7011-8c8a-78f8-283e" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="3342-f9c4-ecb1-f744" name="Light Armour" hidden="false" collective="false" import="true" targetId="2c5f-174f-fa1f-26c7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aff1-7bfc-d04b-fb19" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fbd9-8d5b-e53a-be09" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aff1-7bfc-d04b-fb19" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fbd9-8d5b-e53a-be09" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="d4f2-099d-a571-3648" name="Grenade (Frag/Smoke)" hidden="false" collective="false" import="true" targetId="ccbe-994d-4323-a5b7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1789-568e-cfbc-e774" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e827-d5c2-ca6d-0ea7" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1789-568e-cfbc-e774" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e827-d5c2-ca6d-0ea7" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="bdc8-43b4-311c-ae72" name="Hand Weapon" hidden="false" collective="false" import="true" targetId="751f-ebe1-9a04-524e" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="936c-cf39-ad68-a9a0" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e78b-0fbf-b735-e26b" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="936c-cf39-ad68-a9a0" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e78b-0fbf-b735-e26b" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="e1f7-1c24-b782-ba62" name="Soldier Weapon" hidden="false" collective="false" import="true" targetId="807b-4425-bf96-be3b" type="selectionEntryGroup"/>
@@ -2428,20 +2608,20 @@
     </entryLink>
     <entryLink id="a18f-8a4a-e827-1dbc" name="Sniper" hidden="false" collective="false" import="true" targetId="7ab1-4642-39ca-f8e1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="1209-f78c-0d17-fb90" name="New CategoryLink" hidden="false" targetId="13f2-16cf-e0bd-6624" primary="true"/>
+        <categoryLink id="1209-f78c-0d17-fb90" name="Specialists" hidden="false" targetId="13f2-16cf-e0bd-6624" primary="true"/>
         <categoryLink id="08c3-affd-ad96-1ac2" name="Faction: Stargrave Crew" hidden="false" targetId="7011-8c8a-78f8-283e" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="edce-08c9-7eb9-3201" name="Light Armour" hidden="false" collective="false" import="true" targetId="2c5f-174f-fa1f-26c7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fbb3-1bc2-8d3a-5c6e" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="900d-a02d-c62d-79d7" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fbb3-1bc2-8d3a-5c6e" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="900d-a02d-c62d-79d7" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="a93f-14b8-6d2d-235f" name="Hand Weapon" hidden="false" collective="false" import="true" targetId="751f-ebe1-9a04-524e" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17f5-6966-b036-b6a6" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5024-46e4-2fc2-efc2" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17f5-6966-b036-b6a6" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5024-46e4-2fc2-efc2" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="189d-9d95-4a53-9ede" name="Soldier Weapon" hidden="false" collective="false" import="true" targetId="807b-4425-bf96-be3b" type="selectionEntryGroup"/>
@@ -2450,89 +2630,89 @@
     <entryLink id="6f87-54ba-bdd7-acc4" name="Grenadier" hidden="false" collective="false" import="true" targetId="d9db-e7da-d7fb-2ade" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="f996-4ac9-0f88-3dae" name="Faction: Stargrave Crew" hidden="false" targetId="7011-8c8a-78f8-283e" primary="false"/>
-        <categoryLink id="8603-227f-456a-280d" name="New CategoryLink" hidden="false" targetId="13f2-16cf-e0bd-6624" primary="true"/>
+        <categoryLink id="8603-227f-456a-280d" name="Specialists" hidden="false" targetId="13f2-16cf-e0bd-6624" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="da58-fd9f-c382-4bba" name="Heavy Armour" hidden="false" collective="false" import="true" targetId="b824-fc04-4c55-b49e" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a675-df83-42a6-385f" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c471-16e4-8ec3-271a" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a675-df83-42a6-385f" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c471-16e4-8ec3-271a" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="ee4b-f577-effa-eb53" name="Grenade Launcher" hidden="false" collective="false" import="true" targetId="97aa-31b1-6492-ac84" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8661-a63b-63b2-15f3" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="58a8-1c72-af93-aab6" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8661-a63b-63b2-15f3" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="58a8-1c72-af93-aab6" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="44b8-b20d-14da-eddd" name="Knife" hidden="false" collective="false" import="true" targetId="cb09-0362-58dc-6b9d" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="20eb-25a2-f8e4-b3d6" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8c47-41f6-bde6-fa36" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="20eb-25a2-f8e4-b3d6" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8c47-41f6-bde6-fa36" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="6ec3-6996-9ee0-3af6" name="Pistol" hidden="false" collective="false" import="true" targetId="4039-8fee-a371-8311" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c59-7e56-e7ee-ab5d" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b436-2965-2a81-ad2f" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c59-7e56-e7ee-ab5d" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b436-2965-2a81-ad2f" type="min"/>
           </constraints>
         </entryLink>
       </entryLinks>
     </entryLink>
     <entryLink id="c442-6855-a388-89ef" name="Gunner" hidden="false" collective="false" import="true" targetId="de59-b02d-a3e1-8f76" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="86c4-882f-08bc-5887" name="New CategoryLink" hidden="false" targetId="13f2-16cf-e0bd-6624" primary="true"/>
+        <categoryLink id="86c4-882f-08bc-5887" name="Specialists" hidden="false" targetId="13f2-16cf-e0bd-6624" primary="true"/>
         <categoryLink id="14b2-f310-fa6a-a467" name="Faction: Stargrave Crew" hidden="false" targetId="7011-8c8a-78f8-283e" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="b85c-c104-1098-a276" name="Heavy Armour" hidden="false" collective="false" import="true" targetId="b824-fc04-4c55-b49e" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eaae-65bc-5f34-8382" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="725c-e891-210f-4669" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eaae-65bc-5f34-8382" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="725c-e891-210f-4669" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="42d8-f657-2737-9032" name="Knife" hidden="false" collective="false" import="true" targetId="cb09-0362-58dc-6b9d" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="858e-bcd1-f7bf-0ba8" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1efc-a73e-68b1-91d5" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="858e-bcd1-f7bf-0ba8" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1efc-a73e-68b1-91d5" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="9e8c-a903-e585-33cb" name="Pistol" hidden="false" collective="false" import="true" targetId="4039-8fee-a371-8311" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5cd7-d6e9-d29c-23ba" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="29dc-42ed-54d6-2c93" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5cd7-d6e9-d29c-23ba" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="29dc-42ed-54d6-2c93" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="9331-533a-fe3c-d509" name="Rapid Fire" hidden="false" collective="false" import="true" targetId="5e6a-f427-bc23-ed0a" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="289c-2d37-1de8-a823" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe7b-86dc-6f7f-6322" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="289c-2d37-1de8-a823" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe7b-86dc-6f7f-6322" type="min"/>
           </constraints>
         </entryLink>
       </entryLinks>
     </entryLink>
     <entryLink id="1fc4-b68a-929f-4fca" name="Recruit" hidden="false" collective="false" import="true" targetId="47b9-b6d6-5068-6959" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="f741-377c-9d2a-806d" name="New CategoryLink" hidden="false" targetId="12dd-f26c-ca77-721a" primary="true"/>
+        <categoryLink id="f741-377c-9d2a-806d" name="Soldiers" hidden="false" targetId="12dd-f26c-ca77-721a" primary="true"/>
         <categoryLink id="1883-467f-efd6-a7eb" name="Faction: Stargrave Crew" hidden="false" targetId="7011-8c8a-78f8-283e" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="9c75-8c89-0841-9f56" name="Light Armour" hidden="false" collective="false" import="true" targetId="2c5f-174f-fa1f-26c7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e290-bf5f-4373-a013" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c0be-a052-c343-2d3a" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e290-bf5f-4373-a013" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c0be-a052-c343-2d3a" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="ac8c-c64f-3e14-dca0" name="Knife" hidden="false" collective="false" import="true" targetId="cb09-0362-58dc-6b9d" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="59b5-61a1-854e-c64b" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e739-a01b-b0da-cf5c" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="59b5-61a1-854e-c64b" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e739-a01b-b0da-cf5c" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="99b7-9808-c076-e944" name="Pistol" hidden="false" collective="false" import="true" targetId="4039-8fee-a371-8311" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="14b9-0f88-f480-4f3a" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0ff-7b4f-9b21-bbb7" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="14b9-0f88-f480-4f3a" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0ff-7b4f-9b21-bbb7" type="min"/>
           </constraints>
         </entryLink>
       </entryLinks>
@@ -2540,19 +2720,19 @@
     <entryLink id="50f1-7efb-5f8a-9de3" name="Runner" hidden="false" collective="false" import="true" targetId="f23b-6f05-b103-c7d5" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="8140-f934-d52a-8fa6" name="Faction: Stargrave Crew" hidden="false" targetId="7011-8c8a-78f8-283e" primary="false"/>
-        <categoryLink id="75fa-2774-4c8d-66d9" name="New CategoryLink" hidden="false" targetId="12dd-f26c-ca77-721a" primary="true"/>
+        <categoryLink id="75fa-2774-4c8d-66d9" name="Soldiers" hidden="false" targetId="12dd-f26c-ca77-721a" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="22e4-9736-45d5-7b94" name="Pistol" hidden="false" collective="false" import="true" targetId="4039-8fee-a371-8311" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4773-e3ab-122a-b417" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9022-ba19-a9c5-605f" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4773-e3ab-122a-b417" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9022-ba19-a9c5-605f" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="bd65-c9b2-559f-0c42" name="Knife" hidden="false" collective="false" import="true" targetId="cb09-0362-58dc-6b9d" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e62-aed6-4ba5-6c35" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="565f-1f61-4762-09ce" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e62-aed6-4ba5-6c35" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="565f-1f61-4762-09ce" type="min"/>
           </constraints>
         </entryLink>
       </entryLinks>
@@ -2560,110 +2740,110 @@
     <entryLink id="ba7f-0d61-b3c6-3ccd" name="Hacker" hidden="false" collective="false" import="true" targetId="0c09-0d89-d90d-876b" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="51b9-6296-1334-d081" name="Faction: Stargrave Crew" hidden="false" targetId="7011-8c8a-78f8-283e" primary="false"/>
-        <categoryLink id="a717-1541-6663-2a5a" name="New CategoryLink" hidden="false" targetId="12dd-f26c-ca77-721a" primary="true"/>
+        <categoryLink id="a717-1541-6663-2a5a" name="Soldiers" hidden="false" targetId="12dd-f26c-ca77-721a" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="dfc6-1daf-6d66-892f" name="Pistol" hidden="false" collective="false" import="true" targetId="4039-8fee-a371-8311" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab30-db30-0505-4819" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dcf9-4d04-9e76-19fe" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab30-db30-0505-4819" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dcf9-4d04-9e76-19fe" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="da7a-4d57-9731-d99e" name="Deck" hidden="false" collective="false" import="true" targetId="cb72-75b1-00d6-d034" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be40-e096-e6d7-e0d9" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="08a8-d38f-cc85-ebaf" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be40-e096-e6d7-e0d9" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="08a8-d38f-cc85-ebaf" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="556c-2192-d566-267c" name="Light Armour" hidden="false" collective="false" import="true" targetId="2c5f-174f-fa1f-26c7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4231-57ac-ce09-d715" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c3a9-ae45-5630-db35" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4231-57ac-ce09-d715" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c3a9-ae45-5630-db35" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="c3c0-10f8-6427-ff4c" name="Knife" hidden="false" collective="false" import="true" targetId="cb09-0362-58dc-6b9d" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f34-6053-47e1-670b" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="19fa-18a1-b739-d618" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f34-6053-47e1-670b" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="19fa-18a1-b739-d618" type="min"/>
           </constraints>
         </entryLink>
       </entryLinks>
     </entryLink>
     <entryLink id="2357-b27f-841e-6061" name="Chiseler" hidden="false" collective="false" import="true" targetId="131b-c9c6-1454-f5c4" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="af30-97b1-2ff2-18b3" name="New CategoryLink" hidden="false" targetId="12dd-f26c-ca77-721a" primary="true"/>
+        <categoryLink id="af30-97b1-2ff2-18b3" name="Soldiers" hidden="false" targetId="12dd-f26c-ca77-721a" primary="true"/>
         <categoryLink id="2ab0-4d19-62f3-1c07" name="Faction: Stargrave Crew" hidden="false" targetId="7011-8c8a-78f8-283e" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="dd51-ce5a-909f-5530" name="Light Armour" hidden="false" collective="false" import="true" targetId="2c5f-174f-fa1f-26c7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dcaf-6bf3-10b4-5b03" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="02ca-29d0-daa1-b9c0" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dcaf-6bf3-10b4-5b03" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="02ca-29d0-daa1-b9c0" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="95b8-403a-314b-1b5c" name="Picks" hidden="false" collective="false" import="true" targetId="84b2-39a3-0985-b603" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c628-878b-2813-6de0" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="68b2-7866-a6c1-3331" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c628-878b-2813-6de0" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="68b2-7866-a6c1-3331" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="ba44-4cb0-ad3e-1359" name="Knife" hidden="false" collective="false" import="true" targetId="cb09-0362-58dc-6b9d" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2096-b2af-8845-acdb" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="13ea-c133-1a09-afd8" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2096-b2af-8845-acdb" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="13ea-c133-1a09-afd8" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="9da1-5f00-452f-4c60" name="Pistol" hidden="false" collective="false" import="true" targetId="4039-8fee-a371-8311" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f704-1978-0b53-524d" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e068-a186-6b2e-7d72" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f704-1978-0b53-524d" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e068-a186-6b2e-7d72" type="min"/>
           </constraints>
         </entryLink>
       </entryLinks>
     </entryLink>
     <entryLink id="d6f0-ce33-5aea-4009" name="Guard Dog" hidden="false" collective="false" import="true" targetId="a8f1-fcf4-f430-4f54" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="c15a-ca74-88b0-b6b7" name="New CategoryLink" hidden="false" targetId="12dd-f26c-ca77-721a" primary="true"/>
+        <categoryLink id="c15a-ca74-88b0-b6b7" name="Soldiers" hidden="false" targetId="12dd-f26c-ca77-721a" primary="true"/>
         <categoryLink id="0fbe-80f2-e651-85e3" name="Faction: Stargrave Crew" hidden="false" targetId="7011-8c8a-78f8-283e" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="43d8-e5db-163c-85c1" name="Sentry" hidden="false" collective="false" import="true" targetId="c67f-2f9f-3fc0-9d0d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="1751-5905-5425-d02a" name="New CategoryLink" hidden="false" targetId="12dd-f26c-ca77-721a" primary="true"/>
+        <categoryLink id="1751-5905-5425-d02a" name="Soldiers" hidden="false" targetId="12dd-f26c-ca77-721a" primary="true"/>
         <categoryLink id="df41-a48d-40f0-6194" name="Faction: Stargrave Crew" hidden="false" targetId="7011-8c8a-78f8-283e" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="43a6-afdd-262a-90fa" name="Heavy Armour" hidden="false" collective="false" import="true" targetId="b824-fc04-4c55-b49e" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d463-43ac-e653-c828" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cce5-2a6e-a1e7-4eb3" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d463-43ac-e653-c828" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cce5-2a6e-a1e7-4eb3" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="2298-2a2a-1527-25f7" name="Soldier Weapon" hidden="false" collective="false" import="true" targetId="807b-4425-bf96-be3b" type="selectionEntryGroup"/>
         <entryLink id="9ddf-72b8-c704-d93f" name="Hand Weapon" hidden="false" collective="false" import="true" targetId="751f-ebe1-9a04-524e" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d11-40fe-d319-f94d" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9278-8da3-9d46-eb52" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d11-40fe-d319-f94d" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9278-8da3-9d46-eb52" type="min"/>
           </constraints>
         </entryLink>
       </entryLinks>
     </entryLink>
     <entryLink id="ac03-007d-dada-c15d" name="Trooper" hidden="false" collective="false" import="true" targetId="50cd-3310-aa7c-fc1f" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="d000-e835-14e7-9ea8" name="New CategoryLink" hidden="false" targetId="12dd-f26c-ca77-721a" primary="true"/>
+        <categoryLink id="d000-e835-14e7-9ea8" name="Soldiers" hidden="false" targetId="12dd-f26c-ca77-721a" primary="true"/>
         <categoryLink id="9a07-0f11-f1e4-42be" name="Faction: Stargrave Crew" hidden="false" targetId="7011-8c8a-78f8-283e" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="c70a-b796-990a-d09f" name="Heavy Armour" hidden="false" collective="false" import="true" targetId="b824-fc04-4c55-b49e" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a97d-b29e-8718-4693" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de2d-8bea-9e94-eabb" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a97d-b29e-8718-4693" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de2d-8bea-9e94-eabb" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="8675-6906-5356-08cb" name="Knife" hidden="false" collective="false" import="true" targetId="cb09-0362-58dc-6b9d" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="848d-8c1a-3cfe-df88" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ee1-d884-1e4f-84f4" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="848d-8c1a-3cfe-df88" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ee1-d884-1e4f-84f4" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="72a7-728b-eb5e-3cb0" name="Soldier Weapon" hidden="false" collective="false" import="true" targetId="807b-4425-bf96-be3b" type="selectionEntryGroup"/>
@@ -2671,26 +2851,26 @@
     </entryLink>
     <entryLink id="de70-4ea5-633b-b6d0" name="Medic" hidden="false" collective="false" import="true" targetId="a1cc-ac3b-a9cb-2547" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2991-1161-6fa3-4295" name="New CategoryLink" hidden="false" targetId="12dd-f26c-ca77-721a" primary="true"/>
+        <categoryLink id="2991-1161-6fa3-4295" name="Soldiers" hidden="false" targetId="12dd-f26c-ca77-721a" primary="true"/>
         <categoryLink id="ee6b-435d-f49c-10a6" name="Faction: Stargrave Crew" hidden="false" targetId="7011-8c8a-78f8-283e" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="8493-59a7-63f5-7f1d" name="Light Armour" hidden="false" collective="false" import="true" targetId="2c5f-174f-fa1f-26c7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="67e6-04f7-9e58-422c" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8beb-1575-1315-9e94" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="67e6-04f7-9e58-422c" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8beb-1575-1315-9e94" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="9123-9299-48a6-c2f5" name="Medic Kit" hidden="false" collective="false" import="true" targetId="2579-e6e7-e7dc-73c1" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd8e-6c0b-470d-3dae" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="49cb-6c4b-e620-0ce2" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd8e-6c0b-470d-3dae" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="49cb-6c4b-e620-0ce2" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="7e05-d106-2568-06a9" name="Pistol" hidden="false" collective="false" import="true" targetId="4039-8fee-a371-8311" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="908f-68df-251f-76f1" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2df0-1c48-7870-05c6" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="908f-68df-251f-76f1" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2df0-1c48-7870-05c6" type="min"/>
           </constraints>
         </entryLink>
       </entryLinks>
@@ -2703,20 +2883,20 @@
       <entryLinks>
         <entryLink id="8527-25cb-7bf2-134d" name="Pistol" hidden="false" collective="false" import="true" targetId="4039-8fee-a371-8311" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="76e3-b0bf-995a-1b5a" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5090-a4b1-838a-25d9" type="max"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="76e3-b0bf-995a-1b5a" type="min"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5090-a4b1-838a-25d9" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="f37d-afdd-50ad-3469" name="Light Armour" hidden="false" collective="false" import="true" targetId="2c5f-174f-fa1f-26c7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6afb-f9e8-ad2e-5f69" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e765-8179-68ee-35da" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6afb-f9e8-ad2e-5f69" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e765-8179-68ee-35da" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="3040-a150-4370-0c28" name="Knife" hidden="false" collective="false" import="true" targetId="cb09-0362-58dc-6b9d" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="252c-cc57-1ed0-d43d" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ba1-8877-74f4-f494" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="252c-cc57-1ed0-d43d" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ba1-8877-74f4-f494" type="min"/>
           </constraints>
         </entryLink>
       </entryLinks>
@@ -2729,8 +2909,8 @@
       <entryLinks>
         <entryLink id="f998-398b-3c8a-9385" name="Pistol" hidden="false" collective="false" import="true" targetId="4039-8fee-a371-8311" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8135-0777-9380-9542" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d536-e577-c411-9168" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8135-0777-9380-9542" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d536-e577-c411-9168" type="max"/>
           </constraints>
         </entryLink>
       </entryLinks>
@@ -2751,8 +2931,8 @@
       <selectionEntryGroups>
         <selectionEntryGroup id="486c-f004-0dd3-bf37" name="Weapon" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dafb-252f-369e-0eba" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e381-5a25-ef25-5560" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dafb-252f-369e-0eba" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e381-5a25-ef25-5560" type="min"/>
           </constraints>
           <entryLinks>
             <entryLink id="5c13-0d2b-67a7-2fcb" name="Flamethrower" hidden="false" collective="false" import="true" targetId="4fcb-337a-cabb-7e51" type="selectionEntry"/>
@@ -2761,8 +2941,8 @@
         </selectionEntryGroup>
         <selectionEntryGroup id="1f76-14cb-ed17-2f86" name="Equipment" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d887-7654-5967-143b" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="93e5-fcf5-8db0-4c05" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d887-7654-5967-143b" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="93e5-fcf5-8db0-4c05" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="2c14-d3c6-86de-e454" name="Deck" hidden="false" collective="false" import="true" targetId="cb72-75b1-00d6-d034" type="selectionEntry"/>
@@ -2779,20 +2959,20 @@
       <entryLinks>
         <entryLink id="0cdd-e503-65bf-7f00" name="Pistol" hidden="false" collective="false" import="true" targetId="4039-8fee-a371-8311" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a57c-04e9-c94d-f4a1" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d084-7db4-943e-585e" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a57c-04e9-c94d-f4a1" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d084-7db4-943e-585e" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="8308-c8e2-5a9f-f85b" name="Light Armour" hidden="false" collective="false" import="true" targetId="2c5f-174f-fa1f-26c7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94b5-b73a-f1d5-ace1" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a494-a26c-503b-4078" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94b5-b73a-f1d5-ace1" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a494-a26c-503b-4078" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="409b-089e-ec22-6d12" name="Knife" hidden="false" collective="false" import="true" targetId="cb09-0362-58dc-6b9d" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d3fa-b7c7-046c-0733" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="00e1-a67e-a709-cbaa" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d3fa-b7c7-046c-0733" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="00e1-a67e-a709-cbaa" type="max"/>
           </constraints>
         </entryLink>
       </entryLinks>
@@ -2805,14 +2985,14 @@
       <entryLinks>
         <entryLink id="bb09-129e-46bc-b7ce" name="Heavy Armour" hidden="false" collective="false" import="true" targetId="b824-fc04-4c55-b49e" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4481-ee71-d874-dfbf" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd56-2d8b-5879-da58" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4481-ee71-d874-dfbf" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd56-2d8b-5879-da58" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="122f-a51c-3357-53f5" name="Knife" hidden="false" collective="false" import="true" targetId="cb09-0362-58dc-6b9d" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b71-d731-33a1-c9d4" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa10-dcce-c66c-fdc9" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b71-d731-33a1-c9d4" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa10-dcce-c66c-fdc9" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="d817-ba7f-bbee-cfdc" name="Soldier Weapon" hidden="false" collective="false" import="true" targetId="807b-4425-bf96-be3b" type="selectionEntryGroup"/>
@@ -2826,14 +3006,14 @@
       <entryLinks>
         <entryLink id="fbd9-3476-403f-102e" name="Light Armour" hidden="false" collective="false" import="true" targetId="2c5f-174f-fa1f-26c7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="edeb-4788-09a6-fc90" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf12-d28f-87cf-7067" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="edeb-4788-09a6-fc90" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf12-d28f-87cf-7067" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="febd-2015-af6a-bab6" name="Hand Weapon" hidden="false" collective="false" import="true" targetId="751f-ebe1-9a04-524e" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52db-3d08-28fd-b77a" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba60-bac0-d7a8-6ee2" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52db-3d08-28fd-b77a" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba60-bac0-d7a8-6ee2" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="ed85-ae6b-86bd-3509" name="Soldier Weapon" hidden="false" collective="false" import="true" targetId="807b-4425-bf96-be3b" type="selectionEntryGroup"/>
@@ -2843,24 +3023,24 @@
   <sharedSelectionEntries>
     <selectionEntry id="4cd1-ff48-5eaf-e868" name="Level" hidden="false" collective="false" import="true" type="upgrade">
       <costs>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="807b-4425-bf96-be3b" name="Soldier Weapon" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="076c-7019-f95d-01ad" type="max"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="977a-c070-be34-fe56" type="min"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="076c-7019-f95d-01ad" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="977a-c070-be34-fe56" type="min"/>
       </constraints>
       <entryLinks>
         <entryLink id="9f0c-e9f7-29e7-a72f" name="Carbine" hidden="false" collective="false" import="true" targetId="5458-bb3d-f66c-0c0f" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="2566-f31f-7c96-d7b2" value="0.0"/>
+            <modifier type="set" field="2566-f31f-7c96-d7b2" value="0"/>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2566-f31f-7c96-d7b2" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2566-f31f-7c96-d7b2" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="4e39-0cf5-8ae1-b5fc" name="Shotgun" hidden="false" collective="false" import="true" targetId="1075-090d-31e0-ad87" type="selectionEntry"/>

--- a/Standard Crew.cat
+++ b/Standard Crew.cat
@@ -101,7 +101,7 @@
                 <constraint type="max" value="3" field="selections" scope="parent" shared="true" id="43f9-16f6-af44-2d57"/>
               </constraints>
             </entryLink>
-            <entryLink import="true" name="Other Powers" hidden="false" id="809a-3e64-427e-8f51" type="selectionEntryGroup" targetId="d187-4aa6-4f21-7b77"/>
+            <entryLink import="true" name="Other Powers" hidden="false" id="809a-3e64-427e-8f51" type="selectionEntryGroup" targetId="8b97-db29-9e0e-bce4"/>
           </entryLinks>
           <constraints>
             <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="67b1-03ad-bd0d-7b50"/>
@@ -215,7 +215,7 @@
                 <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="32c3-66d9-86db-9b9e"/>
               </constraints>
             </entryLink>
-            <entryLink import="true" name="Other Powers" hidden="false" id="d12f-f89b-14cd-44ea" type="selectionEntryGroup" targetId="d187-4aa6-4f21-7b77"/>
+            <entryLink import="true" name="Other Powers" hidden="false" id="d12f-f89b-14cd-44ea" type="selectionEntryGroup" targetId="8b97-db29-9e0e-bce4"/>
           </entryLinks>
           <constraints>
             <constraint type="max" value="5" field="selections" scope="parent" shared="true" id="a58b-ea91-9448-aefb"/>
@@ -352,7 +352,7 @@
                 <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="24d7-47ee-7640-9a67"/>
               </constraints>
             </entryLink>
-            <entryLink import="true" name="Other Powers" hidden="false" id="d6f7-d730-8aab-065c" type="selectionEntryGroup" targetId="d187-4aa6-4f21-7b77"/>
+            <entryLink import="true" name="Other Powers" hidden="false" id="d6f7-d730-8aab-065c" type="selectionEntryGroup" targetId="8b97-db29-9e0e-bce4"/>
           </entryLinks>
           <constraints>
             <constraint type="max" value="5" field="selections" scope="parent" shared="true" id="e59a-eed6-f78b-54a2"/>
@@ -466,7 +466,7 @@
                 <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="12fc-7f9f-c24e-2572"/>
               </constraints>
             </entryLink>
-            <entryLink import="true" name="Other Powers" hidden="false" id="2b9a-63c1-5394-2f4b" type="selectionEntryGroup" targetId="d187-4aa6-4f21-7b77"/>
+            <entryLink import="true" name="Other Powers" hidden="false" id="2b9a-63c1-5394-2f4b" type="selectionEntryGroup" targetId="8b97-db29-9e0e-bce4"/>
           </entryLinks>
           <constraints>
             <constraint type="max" value="5" field="selections" scope="parent" shared="true" id="efe6-11a5-fb5e-5a61"/>
@@ -603,7 +603,7 @@
                 <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="b05f-9649-2bbe-de73"/>
               </constraints>
             </entryLink>
-            <entryLink import="true" name="Other Powers" hidden="false" id="ddd7-3b20-77b4-0373" type="selectionEntryGroup" targetId="d187-4aa6-4f21-7b77"/>
+            <entryLink import="true" name="Other Powers" hidden="false" id="ddd7-3b20-77b4-0373" type="selectionEntryGroup" targetId="8b97-db29-9e0e-bce4"/>
           </entryLinks>
           <constraints>
             <constraint type="max" value="5" field="selections" scope="parent" shared="true" id="393b-eb18-c1ff-2858"/>
@@ -726,7 +726,7 @@
                 <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="cf9d-619f-1971-30ac"/>
               </constraints>
             </entryLink>
-            <entryLink import="true" name="Other Powers" hidden="false" id="b30b-5207-51e6-ba95" type="selectionEntryGroup" targetId="d187-4aa6-4f21-7b77"/>
+            <entryLink import="true" name="Other Powers" hidden="false" id="b30b-5207-51e6-ba95" type="selectionEntryGroup" targetId="8b97-db29-9e0e-bce4"/>
           </entryLinks>
           <constraints>
             <constraint type="max" value="5" field="selections" scope="parent" shared="true" id="fe81-c05b-5d06-e595"/>
@@ -849,7 +849,7 @@
                 <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="cff2-c051-4580-1fec"/>
               </constraints>
             </entryLink>
-            <entryLink import="true" name="Other Powers" hidden="false" id="ff81-ed6d-cd53-eea7" type="selectionEntryGroup" targetId="d187-4aa6-4f21-7b77"/>
+            <entryLink import="true" name="Other Powers" hidden="false" id="ff81-ed6d-cd53-eea7" type="selectionEntryGroup" targetId="8b97-db29-9e0e-bce4"/>
           </entryLinks>
           <constraints>
             <constraint type="max" value="5" field="selections" scope="parent" shared="true" id="77ea-1af0-5e7d-a0e1"/>
@@ -972,7 +972,7 @@
                 <constraint type="max" value="3" field="selections" scope="parent" shared="true" id="3e24-b971-3150-2572"/>
               </constraints>
             </entryLink>
-            <entryLink import="true" name="Other Powers" hidden="false" id="7345-a262-8d87-464b" type="selectionEntryGroup" targetId="d187-4aa6-4f21-7b77"/>
+            <entryLink import="true" name="Other Powers" hidden="false" id="7345-a262-8d87-464b" type="selectionEntryGroup" targetId="8b97-db29-9e0e-bce4"/>
           </entryLinks>
           <constraints>
             <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="e863-aeb8-3263-690e"/>
@@ -1086,7 +1086,7 @@
                 <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="8b64-7221-f4c7-59ca"/>
               </constraints>
             </entryLink>
-            <entryLink import="true" name="Other Powers" hidden="false" id="197b-abfc-cafe-7d56" type="selectionEntryGroup" targetId="d187-4aa6-4f21-7b77"/>
+            <entryLink import="true" name="Other Powers" hidden="false" id="197b-abfc-cafe-7d56" type="selectionEntryGroup" targetId="8b97-db29-9e0e-bce4"/>
           </entryLinks>
           <constraints>
             <constraint type="max" value="5" field="selections" scope="parent" shared="true" id="9109-53d1-fa8e-e113"/>
@@ -1209,7 +1209,7 @@
                 <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="069a-674b-13a2-60a8"/>
               </constraints>
             </entryLink>
-            <entryLink import="true" name="Other Powers" hidden="false" id="63f1-0390-e54d-7371" type="selectionEntryGroup" targetId="d187-4aa6-4f21-7b77"/>
+            <entryLink import="true" name="Other Powers" hidden="false" id="63f1-0390-e54d-7371" type="selectionEntryGroup" targetId="8b97-db29-9e0e-bce4"/>
           </entryLinks>
           <constraints>
             <constraint type="max" value="5" field="selections" scope="parent" shared="true" id="22ef-a6f4-8bf7-1989"/>
@@ -1323,7 +1323,7 @@
                 <constraint type="max" value="3" field="selections" scope="parent" shared="true" id="6ff1-fb4b-fa57-ce6e"/>
               </constraints>
             </entryLink>
-            <entryLink import="true" name="Other Powers" hidden="false" id="2a52-2451-42dd-bd56" type="selectionEntryGroup" targetId="d187-4aa6-4f21-7b77"/>
+            <entryLink import="true" name="Other Powers" hidden="false" id="2a52-2451-42dd-bd56" type="selectionEntryGroup" targetId="8b97-db29-9e0e-bce4"/>
           </entryLinks>
           <constraints>
             <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="503f-d0f2-4d78-e1c9"/>
@@ -1437,7 +1437,7 @@
                 <constraint type="max" value="3" field="selections" scope="parent" shared="true" id="574b-7168-a417-ba5d"/>
               </constraints>
             </entryLink>
-            <entryLink import="true" name="Other Powers" hidden="false" id="3028-fd02-c585-6dd2" type="selectionEntryGroup" targetId="d187-4aa6-4f21-7b77"/>
+            <entryLink import="true" name="Other Powers" hidden="false" id="3028-fd02-c585-6dd2" type="selectionEntryGroup" targetId="8b97-db29-9e0e-bce4"/>
           </entryLinks>
           <constraints>
             <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="9805-c681-a836-c51f"/>
@@ -1574,7 +1574,7 @@
                 <constraint type="max" value="3" field="selections" scope="parent" shared="true" id="d846-5de1-e004-b09b"/>
               </constraints>
             </entryLink>
-            <entryLink import="true" name="Other Powers" hidden="false" id="eead-c371-f21a-2f35" type="selectionEntryGroup" targetId="d187-4aa6-4f21-7b77"/>
+            <entryLink import="true" name="Other Powers" hidden="false" id="eead-c371-f21a-2f35" type="selectionEntryGroup" targetId="8b97-db29-9e0e-bce4"/>
           </entryLinks>
           <constraints>
             <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="1f20-f54e-03d3-738e"/>
@@ -1697,7 +1697,7 @@
                 <constraint type="max" value="3" field="selections" scope="parent" shared="true" id="d578-968a-2baa-a77d"/>
               </constraints>
             </entryLink>
-            <entryLink import="true" name="Other Powers" hidden="false" id="b627-40e8-6344-3366" type="selectionEntryGroup" targetId="d187-4aa6-4f21-7b77"/>
+            <entryLink import="true" name="Other Powers" hidden="false" id="b627-40e8-6344-3366" type="selectionEntryGroup" targetId="8b97-db29-9e0e-bce4"/>
           </entryLinks>
           <constraints>
             <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="224b-943a-a03b-0e0c"/>
@@ -1834,7 +1834,7 @@
                 <constraint type="max" value="3" field="selections" scope="parent" shared="true" id="8a34-db5c-a7d2-7576"/>
               </constraints>
             </entryLink>
-            <entryLink import="true" name="Other Powers" hidden="false" id="2211-d867-b98a-182b" type="selectionEntryGroup" targetId="d187-4aa6-4f21-7b77"/>
+            <entryLink import="true" name="Other Powers" hidden="false" id="2211-d867-b98a-182b" type="selectionEntryGroup" targetId="8b97-db29-9e0e-bce4"/>
           </entryLinks>
           <constraints>
             <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="f8cc-7bc4-7d83-bdec"/>
@@ -1948,7 +1948,7 @@
                 <constraint type="max" value="3" field="selections" scope="parent" shared="true" id="122d-76df-284d-2863"/>
               </constraints>
             </entryLink>
-            <entryLink import="true" name="Other Powers" hidden="false" id="2aef-b5e6-5670-1d30" type="selectionEntryGroup" targetId="d187-4aa6-4f21-7b77"/>
+            <entryLink import="true" name="Other Powers" hidden="false" id="2aef-b5e6-5670-1d30" type="selectionEntryGroup" targetId="8b97-db29-9e0e-bce4"/>
           </entryLinks>
           <constraints>
             <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="0b78-86a2-9e68-7e57"/>
@@ -2073,7 +2073,7 @@
                 <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="6119-227e-155f-af8d"/>
               </constraints>
             </entryLink>
-            <entryLink import="true" name="Other Powers" hidden="false" id="e43c-564e-7172-a4fc" type="selectionEntryGroup" targetId="d187-4aa6-4f21-7b77"/>
+            <entryLink import="true" name="Other Powers" hidden="false" id="e43c-564e-7172-a4fc" type="selectionEntryGroup" targetId="8b97-db29-9e0e-bce4"/>
           </entryLinks>
           <constraints>
             <constraint type="max" value="5" field="selections" scope="parent" shared="true" id="f99b-2942-6bc1-bed3"/>
@@ -2187,7 +2187,7 @@
                 <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="ab25-d4bb-5d85-3d51"/>
               </constraints>
             </entryLink>
-            <entryLink import="true" name="Other Powers" hidden="false" id="c6ce-d8a8-f0f5-396c" type="selectionEntryGroup" targetId="d187-4aa6-4f21-7b77"/>
+            <entryLink import="true" name="Other Powers" hidden="false" id="c6ce-d8a8-f0f5-396c" type="selectionEntryGroup" targetId="8b97-db29-9e0e-bce4"/>
           </entryLinks>
           <constraints>
             <constraint type="max" value="5" field="selections" scope="parent" shared="true" id="c6b2-8f0d-ec3e-b103"/>
@@ -2312,7 +2312,7 @@
                 <constraint type="max" value="3" field="selections" scope="parent" shared="true" id="6060-13e5-22d6-24c7"/>
               </constraints>
             </entryLink>
-            <entryLink import="true" name="Other Powers" hidden="false" id="8dc7-d12d-3b90-9974" type="selectionEntryGroup" targetId="d187-4aa6-4f21-7b77"/>
+            <entryLink import="true" name="Other Powers" hidden="false" id="8dc7-d12d-3b90-9974" type="selectionEntryGroup" targetId="8b97-db29-9e0e-bce4"/>
           </entryLinks>
           <constraints>
             <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="9b46-22c3-41f7-9ebe"/>
@@ -2426,7 +2426,7 @@
                 <constraint type="max" value="3" field="selections" scope="parent" shared="true" id="d954-e55a-953c-08d5"/>
               </constraints>
             </entryLink>
-            <entryLink import="true" name="Other Powers" hidden="false" id="e3e8-361d-c70a-2212" type="selectionEntryGroup" targetId="d187-4aa6-4f21-7b77"/>
+            <entryLink import="true" name="Other Powers" hidden="false" id="e3e8-361d-c70a-2212" type="selectionEntryGroup" targetId="8b97-db29-9e0e-bce4"/>
           </entryLinks>
           <constraints>
             <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="7bf0-2cba-4899-80f9"/>

--- a/Stargrave.gst
+++ b/Stargrave.gst
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="b7a1-a7ef-bd2f-c484" name="Stargrave" revision="36" battleScribeVersion="2.03" authorName="Eric Gibert" authorContact="ericgibert@yahoo.fr" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
-  <comment>Stargrave </comment>
+<gameSystem id="b7a1-a7ef-bd2f-c484" name="Stargrave" revision="37" battleScribeVersion="2.03" authorName="Eric Gibert" authorContact="ericgibert@yahoo.fr" xmlns="http://www.battlescribe.net/schema/gameSystemSchema" type="gameSystem">
+  <comment>Stargrave</comment>
   <publications>
-    <publication id="205d-6ed1-3ffa-ebbb" name="Stargrave" publisher="" publicationDate="2021-04-29" publisherUrl="https://ospreypublishing.com/store/osprey-games/stargrave/stargrave"/>
-    <publication id="460c-b731-33cf-903c" name="Quarantine 37" shortName="" publicationDate="2021-09-16" publisherUrl="https://ospreypublishing.com/stargrave-quarantine-37"/>
+    <publication id="205d-6ed1-3ffa-ebbb" name="Stargrave" publicationDate="2021-04-29" publisherUrl="https://ospreypublishing.com/store/osprey-games/stargrave/stargrave"/>
+    <publication id="460c-b731-33cf-903c" name="Quarantine 37" publicationDate="2021-09-16" publisherUrl="https://ospreypublishing.com/stargrave-quarantine-37"/>
   </publications>
   <costTypes>
-    <costType id="97c0-4241-980e-66e8" name="Cr" defaultCostLimit="-1.0" hidden="false"/>
-    <costType id="ef24-ff59-caa4-b0e8" name="Gear Slot" defaultCostLimit="-1.0" hidden="true"/>
+    <costType id="97c0-4241-980e-66e8" name="Cr" defaultCostLimit="-1" hidden="false"/>
+    <costType id="ef24-ff59-caa4-b0e8" name="Gear Slot" defaultCostLimit="-1" hidden="true"/>
   </costTypes>
   <profileTypes>
     <profileType id="e0cd-0aa7-dba3-2af3" name="Model">
@@ -59,12 +59,12 @@
   <categoryEntries>
     <categoryEntry id="13f2-16cf-e0bd-6624" name="Specialists" hidden="false">
       <constraints>
-        <constraint field="selections" scope="force" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1664-617a-4c46-39e3" type="max"/>
+        <constraint field="selections" scope="force" value="4" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1664-617a-4c46-39e3" type="max"/>
       </constraints>
     </categoryEntry>
     <categoryEntry id="12dd-f26c-ca77-721a" name="Soldiers" hidden="false">
       <constraints>
-        <constraint field="selections" scope="force" value="8.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3ca-c4ed-c56b-9c3d" type="max"/>
+        <constraint field="selections" scope="force" value="8" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3ca-c4ed-c56b-9c3d" type="max"/>
       </constraints>
     </categoryEntry>
     <categoryEntry id="7011-8c8a-78f8-283e" name="Faction: Stargrave Crew" hidden="false"/>
@@ -75,12 +75,12 @@
     <categoryEntry id="9ddb-8d0f-b99a-39a5" name="Configuration" hidden="false"/>
     <categoryEntry id="16bf-5402-ac6a-dab3" name="Captain" hidden="false">
       <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c115-7eb2-6be2-e980" type="max"/>
+        <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c115-7eb2-6be2-e980" type="max"/>
       </constraints>
     </categoryEntry>
     <categoryEntry id="8749-37ea-6f9e-0824" name="First Mate" hidden="false">
       <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="04ae-e0df-9a50-e115" type="max"/>
+        <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="04ae-e0df-9a50-e115" type="max"/>
       </constraints>
     </categoryEntry>
     <categoryEntry id="6939-3fb3-687a-2a0b" name="Core Biomorph" hidden="false"/>
@@ -102,7 +102,7 @@
           <modifiers>
             <modifier type="set" field="name" value="Soldiers">
               <conditions>
-                <condition field="selections" scope="force" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="12dd-f26c-ca77-721a" type="atLeast"/>
+                <condition field="selections" scope="force" value="2" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="12dd-f26c-ca77-721a" type="atLeast"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -111,7 +111,7 @@
           <modifiers>
             <modifier type="set" field="name" value="Specialists">
               <conditions>
-                <condition field="selections" scope="force" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="13f2-16cf-e0bd-6624" type="atLeast"/>
+                <condition field="selections" scope="force" value="2" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="13f2-16cf-e0bd-6624" type="atLeast"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -143,8 +143,8 @@
         <entryLink id="cc95-7547-67ab-3883" name="is a Robot" hidden="false" collective="false" import="true" targetId="e6de-0e1b-01a2-306f" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="20.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="20"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="47b9-b6d6-5068-6959" name="Recruit" hidden="false" collective="false" import="true" type="model">
@@ -167,8 +167,8 @@
         <entryLink id="f93e-49ce-ce14-910b" name="is a Robot" hidden="false" collective="false" import="true" targetId="e6de-0e1b-01a2-306f" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f23b-6f05-b103-c7d5" name="Runner" hidden="false" collective="false" import="true" type="model">
@@ -191,8 +191,8 @@
         <entryLink id="ab64-2a38-a5b7-e207" name="is a Robot" hidden="false" collective="false" import="true" targetId="e6de-0e1b-01a2-306f" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="131b-c9c6-1454-f5c4" name="Chiseler" hidden="false" collective="false" import="true" type="model">
@@ -215,8 +215,8 @@
         <entryLink id="fc4a-f2fe-a0e3-f243" name="is a Robot" hidden="false" collective="false" import="true" targetId="e6de-0e1b-01a2-306f" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="20.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="20"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a8f1-fcf4-f430-4f54" name="Guard Dog" hidden="false" collective="false" import="true" type="model">
@@ -242,8 +242,8 @@
         <entryLink id="7882-618d-7f5c-7faa" name="is a Robot" hidden="false" collective="false" import="true" targetId="e6de-0e1b-01a2-306f" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="10.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="10"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c67f-2f9f-3fc0-9d0d" name="Sentry" hidden="false" collective="false" import="true" type="model">
@@ -266,8 +266,8 @@
         <entryLink id="d02f-6884-295d-9cfa" name="is a Robot" hidden="false" collective="false" import="true" targetId="e6de-0e1b-01a2-306f" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="50.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="50"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="50cd-3310-aa7c-fc1f" name="Trooper" hidden="false" collective="false" import="true" type="model">
@@ -290,8 +290,8 @@
         <entryLink id="71ad-ea25-5ae6-3aca" name="is a Robot" hidden="false" collective="false" import="true" targetId="e6de-0e1b-01a2-306f" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="50.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="50"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a1cc-ac3b-a9cb-2547" name="Medic" hidden="false" collective="false" import="true" type="model">
@@ -314,8 +314,8 @@
         <entryLink id="bc5c-8691-8e47-ccad" name="is a Robot" hidden="false" collective="false" import="true" targetId="e6de-0e1b-01a2-306f" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="100.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="100"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="aee4-e6c5-e21b-8623" name="Codebreaker" hidden="false" collective="false" import="true" type="model">
@@ -338,8 +338,8 @@
         <entryLink id="5023-9cba-f03b-2502" name="is a Robot" hidden="false" collective="false" import="true" targetId="e6de-0e1b-01a2-306f" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="75.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="75"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="fa49-9ab4-5565-f466" name="Casecracker" hidden="false" collective="false" import="true" type="model">
@@ -362,8 +362,8 @@
         <entryLink id="8754-fbc2-7828-e90f" name="is a Robot" hidden="false" collective="false" import="true" targetId="e6de-0e1b-01a2-306f" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="75.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="75"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="25d0-2116-83ce-c078" name="Commando" hidden="false" collective="false" import="true" type="model">
@@ -386,8 +386,8 @@
         <entryLink id="27d9-e6e1-c6fc-62c5" name="is a Robot" hidden="false" collective="false" import="true" targetId="e6de-0e1b-01a2-306f" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="75.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="75"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8516-acdf-df6c-426d" name="Pathfinder" hidden="false" collective="false" import="true" type="model">
@@ -410,8 +410,8 @@
         <entryLink id="3d52-874e-7c02-a3fc" name="is a Robot" hidden="false" collective="false" import="true" targetId="e6de-0e1b-01a2-306f" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="100.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="100"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7ab1-4642-39ca-f8e1" name="Sniper" hidden="false" collective="false" import="true" type="model">
@@ -434,8 +434,8 @@
         <entryLink id="4e9a-1708-bff5-e0d5" name="is a Robot" hidden="false" collective="false" import="true" targetId="e6de-0e1b-01a2-306f" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="100.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="100"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d9db-e7da-d7fb-2ade" name="Grenadier" hidden="false" collective="false" import="true" type="model">
@@ -458,8 +458,8 @@
         <entryLink id="f4d6-186a-e8b6-814c" name="is a Robot" hidden="false" collective="false" import="true" targetId="e6de-0e1b-01a2-306f" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="100.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="100"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3af1-995d-6a3f-2164" name="Burner" hidden="false" collective="false" import="true" type="model">
@@ -482,8 +482,8 @@
         <entryLink id="2770-fdc4-bb10-8479" name="is a Robot" hidden="false" collective="false" import="true" targetId="e6de-0e1b-01a2-306f" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="100.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="100"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="de59-b02d-a3e1-8f76" name="Gunner" hidden="false" collective="false" import="true" type="model">
@@ -506,8 +506,8 @@
         <entryLink id="a51a-aadd-d868-c219" name="is a Robot" hidden="false" collective="false" import="true" targetId="e6de-0e1b-01a2-306f" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="100.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="100"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a4c3-a70e-6571-f5f1" name="Armoured Trooper" hidden="false" collective="false" import="true" type="model">
@@ -530,8 +530,8 @@
         <entryLink id="5f5b-be85-73ea-7717" name="is a Robot" hidden="false" collective="false" import="true" targetId="e6de-0e1b-01a2-306f" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="150.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="150"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5458-bb3d-f66c-0c0f" name="Carbine" hidden="false" collective="false" import="true" type="upgrade">
@@ -539,40 +539,40 @@
         <infoLink id="e163-99c4-ffd6-9698" name="Carbine" hidden="false" targetId="33df-9e64-5d0e-ddf0" type="profile"/>
       </infoLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ea4f-6372-4af1-e30b" name="Combat Armour" hidden="false" collective="false" import="true" type="upgrade">
       <entryLinks>
         <entryLink id="8c7e-15a5-4329-572a" name="Pistol" hidden="false" collective="false" import="true" targetId="4039-8fee-a371-8311" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc91-964a-3c5e-fca4" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb6b-b94d-44c7-7b1c" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc91-964a-3c5e-fca4" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb6b-b94d-44c7-7b1c" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="ee73-2fad-2293-6f42" name="Hand Weapon" hidden="false" collective="false" import="true" targetId="751f-ebe1-9a04-524e" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d287-a9d0-e3d9-8684" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f629-f7d0-6274-7e24" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d287-a9d0-e3d9-8684" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f629-f7d0-6274-7e24" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="487b-3dca-bd34-3d3b" name="Filter Mask" hidden="false" collective="false" import="true" targetId="d820-8ec9-e4eb-df4a" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ceaa-6881-6010-f36c" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa4f-99f5-b8e1-a399" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ceaa-6881-6010-f36c" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa4f-99f5-b8e1-a399" type="min"/>
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2c5f-174f-fa1f-26c7" name="Light Armour" hidden="false" collective="false" import="true" type="upgrade">
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5cee-33b2-65b6-c8a0" name="Shield" hidden="false" collective="false" import="true" type="upgrade">
@@ -580,8 +580,8 @@
         <infoLink id="7143-72b8-a61b-c938" name="Shield" hidden="false" targetId="20a2-d49a-fcfb-94af" type="profile"/>
       </infoLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="cb72-75b1-00d6-d034" name="Deck" hidden="false" collective="false" import="true" type="upgrade">
@@ -589,8 +589,8 @@
         <infoLink id="e5a8-25ed-1ce1-877b" name="Deck" hidden="false" targetId="f616-0201-95ab-bfa7" type="profile"/>
       </infoLinks>
       <costs>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d820-8ec9-e4eb-df4a" name="Filter Mask" hidden="false" collective="false" import="true" type="upgrade">
@@ -598,8 +598,8 @@
         <infoLink id="25c2-ca24-ef8f-f816" name="Filter Mask" hidden="false" targetId="49f2-90c7-f4c1-f060" type="profile"/>
       </infoLinks>
       <costs>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2579-e6e7-e7dc-73c1" name="Medic Kit" hidden="false" collective="false" import="true" type="upgrade">
@@ -607,8 +607,8 @@
         <infoLink id="da93-4cfd-0b3d-c3e6" name="Medic Kit" hidden="false" targetId="5907-12d3-16ad-484f" type="profile"/>
       </infoLinks>
       <costs>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="84b2-39a3-0985-b603" name="Picks" hidden="false" collective="false" import="true" type="upgrade">
@@ -616,8 +616,8 @@
         <infoLink id="4351-260c-e500-8d6c" name="Picks" hidden="false" targetId="434d-59ed-0898-1ac7" type="profile"/>
       </infoLinks>
       <costs>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4fcb-337a-cabb-7e51" name="Flamethrower" hidden="false" collective="false" import="true" type="upgrade">
@@ -625,8 +625,8 @@
         <infoLink id="27a5-46bf-cf45-0395" name="Flamethrower" hidden="false" targetId="b73f-ed92-99a9-ea6f" type="profile"/>
       </infoLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="97aa-31b1-6492-ac84" name="Grenade Launcher" hidden="false" collective="false" import="true" type="upgrade">
@@ -634,8 +634,8 @@
         <infoLink id="5901-45b4-005b-5dd1" name="Grenade Launcher" hidden="false" targetId="fb0d-2aee-5b14-124d" type="profile"/>
       </infoLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ccbe-994d-4323-a5b7" name="Grenade (Frag/Smoke)" hidden="false" collective="false" import="true" type="upgrade">
@@ -643,8 +643,8 @@
         <infoLink id="ebe2-7fe9-ba91-d3da" name="Grenade (Frag/Smoke)" hidden="false" targetId="3e4d-99d7-96e7-f55a" type="profile"/>
       </infoLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="751f-ebe1-9a04-524e" name="Hand Weapon" hidden="false" collective="false" import="true" type="upgrade">
@@ -652,8 +652,8 @@
         <infoLink id="b895-88b4-bfde-8f5c" name="Hand Weapon" hidden="false" targetId="9474-d826-128b-3e89" type="profile"/>
       </infoLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="cb09-0362-58dc-6b9d" name="Knife" hidden="false" collective="false" import="true" type="upgrade">
@@ -661,8 +661,8 @@
         <infoLink id="75f6-9a6c-bd2b-8987" name="Knife" hidden="false" targetId="1ed7-8d7c-f190-78d2" type="profile"/>
       </infoLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4039-8fee-a371-8311" name="Pistol" hidden="false" collective="false" import="true" type="upgrade">
@@ -670,8 +670,8 @@
         <infoLink id="7732-f87e-f90b-d32f" name="Pistol" hidden="false" targetId="3a81-e812-849e-1d92" type="profile"/>
       </infoLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5e6a-f427-bc23-ed0a" name="Rapid Fire" hidden="false" collective="false" import="true" type="upgrade">
@@ -679,8 +679,8 @@
         <infoLink id="1efd-9eb7-9c41-0cae" name="Rapid Fire" hidden="false" targetId="b3ca-b785-4ce7-ec01" type="profile"/>
       </infoLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1075-090d-31e0-ad87" name="Shotgun" hidden="false" collective="false" import="true" type="upgrade">
@@ -688,8 +688,8 @@
         <infoLink id="c384-15af-5222-7e1f" name="Shotgun" hidden="false" targetId="a452-5648-e9ae-773e" type="profile"/>
       </infoLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f80d-224c-77b3-3bc8" name="Unarmed" hidden="false" collective="false" import="true" type="upgrade">
@@ -697,26 +697,26 @@
         <infoLink id="a800-fd14-3add-b1c3" name="Unarmed" hidden="false" targetId="6d34-5bce-381a-5876" type="profile"/>
       </infoLinks>
       <costs>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="b824-fc04-4c55-b49e" name="Heavy Armour" hidden="false" collective="false" import="true" type="upgrade">
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e6de-0e1b-01a2-306f" name="is a Robot" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="950a-cd3d-a6a4-2232" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="950a-cd3d-a6a4-2232" type="max"/>
       </constraints>
       <categoryLinks>
         <categoryLink id="03d2-8883-2e4a-0ee5" name="Robot" hidden="false" targetId="f4d2-cac3-ede8-a8dd" primary="false"/>
       </categoryLinks>
       <costs>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3094-bb20-c571-1ce3" name="Snap-shot" hidden="false" collective="false" import="true" type="upgrade">
@@ -724,8 +724,8 @@
         <infoLink id="ecd6-1476-9e7f-43b1" name="Snap-shot" hidden="false" targetId="1181-23e9-c3a4-035e" type="profile"/>
       </infoLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2142-0f14-2ee3-210e" name="Indestructible Carbine" hidden="false" collective="false" import="true" type="upgrade">
@@ -733,17 +733,17 @@
         <infoLink id="a017-e9eb-bc28-2545" name="Indestructible Carbine" hidden="false" targetId="4e7e-ac64-3f76-e35d" type="profile"/>
       </infoLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7d86-9352-f297-367e" name="Core Power" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c171-d493-60bc-6247" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c171-d493-60bc-6247" type="max"/>
       </constraints>
       <costs>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ddaf-6fd9-0c24-f268" name="Gunfighter" publicationId="460c-b731-33cf-903c" page="17" hidden="false" collective="false" import="true" type="model">
@@ -769,8 +769,8 @@
         <entryLink id="2968-c670-7864-0a0a" name="is a Robot" hidden="false" collective="false" import="true" targetId="e6de-0e1b-01a2-306f" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="100.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="100"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="870d-7d2b-9017-6253" name="Mule" publicationId="460c-b731-33cf-903c" page="18" hidden="false" collective="false" import="true" type="model">
@@ -801,8 +801,8 @@
         <categoryLink id="5a77-8643-9495-cb0b" name="Robot" hidden="false" targetId="f4d2-cac3-ede8-a8dd" primary="false"/>
       </categoryLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="50.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="50"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="edc8-3053-99c7-59c8" name="Q-Bot" publicationId="460c-b731-33cf-903c" page="19" hidden="false" collective="false" import="true" type="model">
@@ -823,8 +823,8 @@
         <categoryLink id="c42b-2312-0f14-9ea4" name="Robot" hidden="false" targetId="f4d2-cac3-ede8-a8dd" primary="false"/>
       </categoryLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="50.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="50"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ec79-99ee-b2ac-4037" name="Ravaged" publicationId="460c-b731-33cf-903c" page="20" hidden="false" collective="false" import="true" type="model">
@@ -850,8 +850,8 @@
         <entryLink id="fc91-ad22-efac-3d7a" name="is a Robot" hidden="false" collective="false" import="true" targetId="e6de-0e1b-01a2-306f" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="acf7-1340-bcfb-7676" name="Ravaged Trooper" publicationId="460c-b731-33cf-903c" page="21" hidden="false" collective="false" import="true" type="model">
@@ -877,8 +877,8 @@
         <entryLink id="e32b-0fc2-d1a3-1d93" name="is a Robot" hidden="false" collective="false" import="true" targetId="e6de-0e1b-01a2-306f" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="50.0"/>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="50"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="413f-5fcd-3d6e-120c" name="Trophy-Taker" publicationId="460c-b731-33cf-903c" page="21" hidden="false" collective="false" import="true" type="model">
@@ -905,8 +905,8 @@
         <entryLink id="ef76-6ab9-3ef6-6949" name="is a Robot" hidden="false" collective="false" import="true" targetId="e6de-0e1b-01a2-306f" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
-        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="100.0"/>
+        <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+        <cost name="Cr" typeId="97c0-4241-980e-66e8" value="100"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -915,7 +915,7 @@
       <selectionEntries>
         <selectionEntry id="9827-cef4-50e1-5243" name="Adrenaline Surge" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="527b-3f64-9621-1bfd" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="527b-3f64-9621-1bfd" type="max"/>
           </constraints>
           <profiles>
             <profile id="d252-a4e3-8337-accb" name="Adrenaline Surge" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -924,12 +924,12 @@
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6939-3fb3-687a-2a0b" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6939-3fb3-687a-2a0b" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -948,17 +948,14 @@
 This figure immediately gains an additional action during this activation, and an additional action in their next activation as well.</description>
             </rule>
           </rules>
-          <entryLinks>
-            <entryLink id="b644-ff9c-8c66-4dab" name="Core Power" hidden="false" collective="false" import="true" targetId="7d86-9352-f297-367e" type="selectionEntry"/>
-          </entryLinks>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="983a-fdc1-e31c-f8b6" name="Antigravity Projection" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7de2-ed6c-ae78-7537" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7de2-ed6c-ae78-7537" type="max"/>
           </constraints>
           <profiles>
             <profile id="1504-a6e8-9e83-d8a6" name="Antigravity Projection" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -967,12 +964,12 @@ This figure immediately gains an additional action during this activation, and a
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8702-3db8-4e88-faf8" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8702-3db8-4e88-faf8" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -992,13 +989,13 @@ The target figure gains the Levitate attribute (page 156) for the rest of the ga
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="f7b1-e169-7c8a-d891" name="Armour Plates" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cecd-67d2-98e7-43c4" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cecd-67d2-98e7-43c4" type="max"/>
           </constraints>
           <profiles>
             <profile id="7d7e-4cec-46d3-4c9b" name="Armour Plates" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -1007,12 +1004,12 @@ The target figure gains the Levitate attribute (page 156) for the rest of the ga
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6939-3fb3-687a-2a0b" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6939-3fb3-687a-2a0b" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -1033,13 +1030,13 @@ This power can be used Out of Game (B), in which case the activating figure star
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="1481-ddf7-8385-0a43" name="Armoury" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3337-2bc2-6628-76c7" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3337-2bc2-6628-76c7" type="max"/>
           </constraints>
           <profiles>
             <profile id="593f-375d-a6b2-6735" name="Armoury" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -1048,12 +1045,12 @@ This power can be used Out of Game (B), in which case the activating figure star
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1510-fec4-0334-8026" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1510-fec4-0334-8026" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -1074,13 +1071,13 @@ Alternatively, one standard (not Advanced Technology) pistol, carbine, or shotgu
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="7662-906d-dedd-9987" name="Bait and Switch" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c286-cf9e-0408-c660" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c286-cf9e-0408-c660" type="max"/>
           </constraints>
           <profiles>
             <profile id="b4fb-17a5-2a9f-5c3f" name="Bait and Switch" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -1089,12 +1086,12 @@ Alternatively, one standard (not Advanced Technology) pistol, carbine, or shotgu
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e49-f5d3-e9cd-c200" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e49-f5d3-e9cd-c200" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -1114,13 +1111,13 @@ This power may only be used against a soldier carrying a loot token. That figure
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6ca7-fd7c-852b-75f8" name="Break Lock" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5626-b877-1ffe-93f2" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5626-b877-1ffe-93f2" type="max"/>
           </constraints>
           <profiles>
             <profile id="3932-2550-f724-e6c8" name="Break Lock" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -1129,12 +1126,12 @@ This power may only be used against a soldier carrying a loot token. That figure
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9e36-ac96-3132-f141" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9e36-ac96-3132-f141" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -1154,13 +1151,13 @@ Immediately unlocks one physical-loot counter.</description>
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="b42d-f5a8-3fbf-69b4" name="Bribe" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b49d-5d7b-bdf5-43d8" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b49d-5d7b-bdf5-43d8" type="max"/>
           </constraints>
           <profiles>
             <profile id="2586-03bb-2f54-84ec" name="Bribe" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -1169,12 +1166,12 @@ Immediately unlocks one physical-loot counter.</description>
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e49-f5d3-e9cd-c200" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e49-f5d3-e9cd-c200" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -1194,13 +1191,13 @@ If successful, place one bribe token next to the table and make your opponent aw
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="ce91-0e3d-fef5-9a35" name="Camouflage" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a032-fa3f-a666-c1ed" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a032-fa3f-a666-c1ed" type="max"/>
           </constraints>
           <profiles>
             <profile id="5d19-7fef-0115-79f6" name="Camouflage" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -1211,15 +1208,15 @@ If successful, place one bribe token next to the table and make your opponent aw
                       <conditionGroups>
                         <conditionGroup type="and">
                           <conditions>
-                            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1795-c4e8-6ca2-380b" type="notInstanceOf"/>
-                            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6939-3fb3-687a-2a0b" type="notInstanceOf"/>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1795-c4e8-6ca2-380b" type="notInstanceOf"/>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6939-3fb3-687a-2a0b" type="notInstanceOf"/>
                           </conditions>
                         </conditionGroup>
                       </conditionGroups>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -1239,13 +1236,13 @@ No figure may draw line of sight to this figure if it is more than 12” away. I
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="adf5-a191-d438-0600" name="Cancel Power" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad91-458c-7c7b-36ac" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad91-458c-7c7b-36ac" type="max"/>
           </constraints>
           <profiles>
             <profile id="f0be-20a6-131e-7de5" name="Cancel Power" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -1254,12 +1251,12 @@ No figure may draw line of sight to this figure if it is more than 12” away. I
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e49-f5d3-e9cd-c200" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e49-f5d3-e9cd-c200" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -1279,13 +1276,13 @@ Immediately cancels all effects of one ongoing Line of Sight power. It has no ef
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="e35b-02c4-9278-c0d0" name="Command" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="72ec-30d6-22c5-5b50" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="72ec-30d6-22c5-5b50" type="max"/>
           </constraints>
           <profiles>
             <profile id="bc37-1318-e4d8-d3fe" name="Command" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -1294,12 +1291,12 @@ Immediately cancels all effects of one ongoing Line of Sight power. It has no ef
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1510-fec4-0334-8026" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1510-fec4-0334-8026" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -1319,13 +1316,13 @@ Select one member of the crew that is in line of sight. That figure now activate
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="f3ff-525d-0b16-f5c4" name="Concealed Firearm" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff01-08b9-9777-8b5f" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff01-08b9-9777-8b5f" type="max"/>
           </constraints>
           <profiles>
             <profile id="ba3c-4c0f-17fd-e7a7" name="Concealed Firearm" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -1334,12 +1331,12 @@ Select one member of the crew that is in line of sight. That figure now activate
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e49-f5d3-e9cd-c200" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e49-f5d3-e9cd-c200" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -1359,13 +1356,13 @@ This power may only be used while a figure is in combat. The figure may make one
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="19a9-6347-e598-dbe4" name="Control Animal" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce0e-c3ed-2d8e-51bb" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce0e-c3ed-2d8e-51bb" type="max"/>
           </constraints>
           <profiles>
             <profile id="5702-dbbe-d7e8-6f1d" name="Control Animal" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -1374,12 +1371,12 @@ This power may only be used while a figure is in combat. The figure may make one
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2934-b054-68dc-0468" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2934-b054-68dc-0468" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -1399,13 +1396,13 @@ This power may only be used against uncontrolled animals. The target animal must
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="ced1-9123-5fc0-6591" name="Control Robot" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b18c-0a4e-fc33-f1fc" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b18c-0a4e-fc33-f1fc" type="max"/>
           </constraints>
           <profiles>
             <profile id="a5a8-36ec-d8ae-9b7c" name="Control Robot" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -1416,15 +1413,15 @@ This power may only be used against uncontrolled animals. The target animal must
                       <conditionGroups>
                         <conditionGroup type="and">
                           <conditions>
-                            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9d84-3333-57c7-92ea" type="notInstanceOf"/>
-                            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1795-c4e8-6ca2-380b" type="notInstanceOf"/>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9d84-3333-57c7-92ea" type="notInstanceOf"/>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1795-c4e8-6ca2-380b" type="notInstanceOf"/>
                           </conditions>
                         </conditionGroup>
                       </conditionGroups>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -1444,8 +1441,8 @@ Select one robot in line of sight. That robot must make an immediate Will Roll (
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="f232-82d8-f2e3-04f6" name="Coordinated Fire" hidden="false" collective="false" import="true" type="upgrade">
@@ -1455,7 +1452,7 @@ the duration of the game. This may not take a figure
 above +5 Shoot. A figure may only benefit from one
 Coordinated Fire Power at a time.</comment>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1404-c0c2-bea0-a39d" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1404-c0c2-bea0-a39d" type="max"/>
           </constraints>
           <profiles>
             <profile id="49b4-3e7b-010e-bca1" name="Coordinated Fire" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -1464,12 +1461,12 @@ Coordinated Fire Power at a time.</comment>
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1510-fec4-0334-8026" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1510-fec4-0334-8026" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -1489,13 +1486,13 @@ The target member of the crew receives +1 Shoot for the duration of the game. Th
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="3553-504d-acd3-3b8f" name="Create Robot" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7211-bc00-abdc-1a38" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7211-bc00-abdc-1a38" type="max"/>
           </constraints>
           <profiles>
             <profile id="ad77-e258-5bd7-6aa1" name="Create Robot" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -1504,12 +1501,12 @@ The target member of the crew receives +1 Shoot for the duration of the game. Th
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9d84-3333-57c7-92ea" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9d84-3333-57c7-92ea" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -1529,13 +1526,13 @@ The player may immediately add one robot soldier to their crew for no cost. This
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="a879-0ab6-5f40-d4ca" name="Dark Energy" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca80-bbe4-2978-5b8c" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca80-bbe4-2978-5b8c" type="max"/>
           </constraints>
           <profiles>
             <profile id="c0ac-8c08-9841-356d" name="Dark Energy" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -1544,12 +1541,12 @@ The player may immediately add one robot soldier to their crew for no cost. This
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2934-b054-68dc-0468" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2934-b054-68dc-0468" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -1569,13 +1566,13 @@ The figure makes a +5 Shooting attack against any target within 12”. This atta
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="fa15-9dbd-ecc9-ce03" name="Data Jump" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="430e-87ab-f0cb-4dfe" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="430e-87ab-f0cb-4dfe" type="max"/>
           </constraints>
           <profiles>
             <profile id="aa87-da01-32ab-caae" name="Data Jump" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -1586,15 +1583,15 @@ The figure makes a +5 Shooting attack against any target within 12”. This atta
                       <conditionGroups>
                         <conditionGroup type="and">
                           <conditions>
-                            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8702-3db8-4e88-faf8" type="notInstanceOf"/>
-                            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e49-f5d3-e9cd-c200" type="notInstanceOf"/>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8702-3db8-4e88-faf8" type="notInstanceOf"/>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e49-f5d3-e9cd-c200" type="notInstanceOf"/>
                           </conditions>
                         </conditionGroup>
                       </conditionGroups>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -1614,13 +1611,13 @@ This power may only target a member of the same warband that is carrying a data-
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d473-312c-56b8-50e5" name="Data Knock" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e35d-0fdb-0f92-b156" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e35d-0fdb-0f92-b156" type="max"/>
           </constraints>
           <profiles>
             <profile id="3f79-5594-7106-b19b" name="Data Knock" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -1629,15 +1626,15 @@ This power may only target a member of the same warband that is carrying a data-
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditionGroups>
                         <conditionGroup type="and">
                           <conditions>
-                            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8702-3db8-4e88-faf8" type="notInstanceOf"/>
-                            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1795-c4e8-6ca2-380b" type="notInstanceOf"/>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8702-3db8-4e88-faf8" type="notInstanceOf"/>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1795-c4e8-6ca2-380b" type="notInstanceOf"/>
                           </conditions>
                         </conditionGroup>
                       </conditionGroups>
@@ -1659,13 +1656,13 @@ Immediately unlocks one data-loot counter.</description>
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="2102-e89e-94ab-6154" name="Data Skip" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4752-be41-52ab-f7eb" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4752-be41-52ab-f7eb" type="max"/>
           </constraints>
           <profiles>
             <profile id="8000-8c60-1d75-3126" name="Data Skip" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -1674,12 +1671,12 @@ Immediately unlocks one data-loot counter.</description>
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8702-3db8-4e88-faf8" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8702-3db8-4e88-faf8" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -1699,13 +1696,13 @@ This power targets an unlocked data-loot token or a figure carrying such a token
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="1c92-e72e-0b83-21bc" name="Destroy Weapon" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1aac-2ae8-930a-037b" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1aac-2ae8-930a-037b" type="max"/>
           </constraints>
           <profiles>
             <profile id="3a99-9147-5780-b672" name="Destroy Weapon" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -1714,12 +1711,12 @@ This power targets an unlocked data-loot token or a figure carrying such a token
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9e36-ac96-3132-f141" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9e36-ac96-3132-f141" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -1739,13 +1736,13 @@ This power may be used against any figure within 12”. The activator may choose
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="2349-b38d-54bd-a761" name="Drone" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6962-d104-e257-d916" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6962-d104-e257-d916" type="max"/>
           </constraints>
           <profiles>
             <profile id="221d-430c-c5d9-6c76" name="Drone" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -1756,15 +1753,15 @@ This power may be used against any figure within 12”. The activator may choose
                       <conditionGroups>
                         <conditionGroup type="and">
                           <conditions>
-                            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8702-3db8-4e88-faf8" type="notInstanceOf"/>
-                            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9d84-3333-57c7-92ea" type="notInstanceOf"/>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8702-3db8-4e88-faf8" type="notInstanceOf"/>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9d84-3333-57c7-92ea" type="notInstanceOf"/>
                           </conditions>
                         </conditionGroup>
                       </conditionGroups>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -1784,13 +1781,13 @@ Place a drone next to the activator (see Chapter Six: Bestiary, page 144). This 
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="1bcd-da52-9de7-aaeb" name="Electromagnetic Pulse" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac00-dbbc-1c8a-9b2a" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac00-dbbc-1c8a-9b2a" type="max"/>
           </constraints>
           <profiles>
             <profile id="3b2e-9575-d174-79e5" name="Electromagnetic Pulse" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -1799,15 +1796,15 @@ Place a drone next to the activator (see Chapter Six: Bestiary, page 144). This 
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditionGroups>
                         <conditionGroup type="and">
                           <conditions>
-                            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8702-3db8-4e88-faf8" type="notInstanceOf"/>
-                            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9d84-3333-57c7-92ea" type="notInstanceOf"/>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8702-3db8-4e88-faf8" type="notInstanceOf"/>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9d84-3333-57c7-92ea" type="notInstanceOf"/>
                           </conditions>
                         </conditionGroup>
                       </conditionGroups>
@@ -1830,13 +1827,13 @@ If targeted against a non-robot figure, all firearms carried by that figure imme
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6499-5fd1-ea15-c7fb" name="Energy Shield" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01bd-7cbd-4b2c-ea74" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01bd-7cbd-4b2c-ea74" type="max"/>
           </constraints>
           <profiles>
             <profile id="99d3-67d3-9bae-1cc7" name="Energy Shield" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -1845,15 +1842,15 @@ If targeted against a non-robot figure, all firearms carried by that figure imme
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditionGroups>
                         <conditionGroup type="and">
                           <conditions>
-                            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1510-fec4-0334-8026" type="notInstanceOf"/>
-                            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1795-c4e8-6ca2-380b" type="notInstanceOf"/>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1510-fec4-0334-8026" type="notInstanceOf"/>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1795-c4e8-6ca2-380b" type="notInstanceOf"/>
                           </conditions>
                         </conditionGroup>
                       </conditionGroups>
@@ -1875,13 +1872,13 @@ A small energy shield forms around the user. This shield absorbs the next 3 poin
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="9d44-c3b7-a451-cb47" name="Fling" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="999f-a1c4-efe3-093f" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="999f-a1c4-efe3-093f" type="max"/>
           </constraints>
           <profiles>
             <profile id="a33f-7f33-e5f3-333e" name="Fling" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -1890,12 +1887,12 @@ A small energy shield forms around the user. This shield absorbs the next 3 poin
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6939-3fb3-687a-2a0b" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6939-3fb3-687a-2a0b" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -1917,13 +1914,13 @@ make an immediate Fight Roll (TN16). If it fails, the activator may move the tar
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="8d15-3692-a0c4-8cd1" name="Fortune" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3b4-bb2e-faf9-1017" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3b4-bb2e-faf9-1017" type="max"/>
           </constraints>
           <profiles>
             <profile id="ba7b-f575-c6c2-8b55" name="Fortune" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -1932,15 +1929,15 @@ make an immediate Fight Roll (TN16). If it fails, the activator may move the tar
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditionGroups>
                         <conditionGroup type="and">
                           <conditions>
-                            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1510-fec4-0334-8026" type="notInstanceOf"/>
-                            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e49-f5d3-e9cd-c200" type="notInstanceOf"/>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1510-fec4-0334-8026" type="notInstanceOf"/>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e49-f5d3-e9cd-c200" type="notInstanceOf"/>
                           </conditions>
                         </conditionGroup>
                       </conditionGroups>
@@ -1962,13 +1959,13 @@ Place a fortune token either next to the figure or on your crew sheet next to th
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="5d11-0e8b-a4ed-f073" name="Haggle" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9485-dc0b-7597-9c9d" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9485-dc0b-7597-9c9d" type="max"/>
           </constraints>
           <profiles>
             <profile id="b03b-af67-876e-f0c7" name="Haggle" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -1977,12 +1974,12 @@ Place a fortune token either next to the figure or on your crew sheet next to th
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e49-f5d3-e9cd-c200" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e49-f5d3-e9cd-c200" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -2002,13 +1999,13 @@ This power may be used whenever the crew sells anything. The crew receives 20% m
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="0abc-8010-2ba1-7f99" name="Heal" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="56b2-72e0-4a50-3d1b" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="56b2-72e0-4a50-3d1b" type="max"/>
           </constraints>
           <profiles>
             <profile id="f9db-2d2c-6cec-8342" name="Heal" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -2017,12 +2014,12 @@ This power may be used whenever the crew sells anything. The crew receives 20% m
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2934-b054-68dc-0468" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2934-b054-68dc-0468" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -2042,13 +2039,13 @@ This power restores up to 5 points of lost Health to a target figure within 6”
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="268f-b2d0-3860-767e" name="Holographic Wall" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff12-ae0c-7591-7ebb" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff12-ae0c-7591-7ebb" type="max"/>
           </constraints>
           <profiles>
             <profile id="88e6-a779-1d59-9271" name="Holographic Wall" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -2057,12 +2054,12 @@ This power restores up to 5 points of lost Health to a target figure within 6”
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8702-3db8-4e88-faf8" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8702-3db8-4e88-faf8" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -2082,13 +2079,13 @@ Creates a holographic wall 6” long and 3” high. No line of sight may be draw
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="4a82-46aa-fa6a-2fcb" name="Life Leach" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3df9-245e-ccd7-9f75" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3df9-245e-ccd7-9f75" type="max"/>
           </constraints>
           <profiles>
             <profile id="be59-ec5c-4137-7b13" name="Life Leach" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -2097,12 +2094,12 @@ Creates a holographic wall 6” long and 3” high. No line of sight may be draw
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2934-b054-68dc-0468" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2934-b054-68dc-0468" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -2123,13 +2120,13 @@ and counts as an uncontrolled figure for the rest of the game. (Armour Interfere
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="45ef-337b-3bc2-8876" name="Lift" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b5e9-ded4-6b72-cde2" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b5e9-ded4-6b72-cde2" type="max"/>
           </constraints>
           <profiles>
             <profile id="fad9-b548-73b8-b9e4" name="Lift" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -2138,12 +2135,12 @@ and counts as an uncontrolled figure for the rest of the game. (Armour Interfere
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9e36-ac96-3132-f141" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9e36-ac96-3132-f141" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -2163,13 +2160,13 @@ Immediately move one member of the same crew that is in line of sight 6” in an
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="ecad-219f-1624-e03c" name="Mystic Trance" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3814-5e4d-c76f-ae5c" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3814-5e4d-c76f-ae5c" type="max"/>
           </constraints>
           <profiles>
             <profile id="8219-480a-6e13-5255" name="Mystic Trance" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -2178,12 +2175,12 @@ Immediately move one member of the same crew that is in line of sight 6” in an
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2934-b054-68dc-0468" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2934-b054-68dc-0468" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -2203,13 +2200,13 @@ If successfully activated, the figure may attempt to use one of their other powe
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="bfff-4c40-34ce-aad4" name="Power Spike" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a95-c19b-7494-5365" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a95-c19b-7494-5365" type="max"/>
           </constraints>
           <profiles>
             <profile id="0b3a-8c05-082b-787c" name="Power Spike" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -2220,15 +2217,15 @@ If successfully activated, the figure may attempt to use one of their other powe
                       <conditionGroups>
                         <conditionGroup type="and">
                           <conditions>
-                            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1510-fec4-0334-8026" type="notInstanceOf"/>
-                            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1795-c4e8-6ca2-380b" type="notInstanceOf"/>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1510-fec4-0334-8026" type="notInstanceOf"/>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1795-c4e8-6ca2-380b" type="notInstanceOf"/>
                           </conditions>
                         </conditionGroup>
                       </conditionGroups>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -2248,13 +2245,13 @@ The next time this figure makes a Shooting attack with a carbine, pistol, or sho
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="a04d-b0bc-edfe-20d6" name="Psionic Fire" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6327-4fee-79ed-79a8" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6327-4fee-79ed-79a8" type="max"/>
           </constraints>
           <profiles>
             <profile id="5d55-6604-71d7-2300" name="Psionic Fire" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -2263,12 +2260,12 @@ The next time this figure makes a Shooting attack with a carbine, pistol, or sho
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9e36-ac96-3132-f141" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9e36-ac96-3132-f141" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -2288,13 +2285,13 @@ The activator should place two flamethrower templates as thought the figure had 
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="4898-8a89-2807-f7bf" name="Pull" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d8de-7fb1-a6e5-1043" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d8de-7fb1-a6e5-1043" type="max"/>
           </constraints>
           <profiles>
             <profile id="e543-e5dd-71f7-2aad" name="Pull" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -2303,12 +2300,12 @@ The activator should place two flamethrower templates as thought the figure had 
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9e36-ac96-3132-f141" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9e36-ac96-3132-f141" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -2328,13 +2325,13 @@ The target figure must make a Will Roll (TN16). If it fails, move that figure up
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="72c2-30d7-9204-ccf7" name="Puppet Master" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b504-cc23-0aaa-8f8f" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b504-cc23-0aaa-8f8f" type="max"/>
           </constraints>
           <profiles>
             <profile id="818c-c9fe-bec9-4335" name="Puppet Master" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -2343,12 +2340,12 @@ The target figure must make a Will Roll (TN16). If it fails, move that figure up
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2934-b054-68dc-0468" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2934-b054-68dc-0468" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -2368,13 +2365,13 @@ Choose one non-robot member of the crew that has been reduced to 0 Health during
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="73c8-27f8-269c-b0e7" name="Psychic Shield" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8062-25c4-6097-470f" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8062-25c4-6097-470f" type="max"/>
           </constraints>
           <profiles>
             <profile id="a562-1e0f-4559-4400" name="Psychic Shield" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -2383,12 +2380,12 @@ Choose one non-robot member of the crew that has been reduced to 0 Health during
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9e36-ac96-3132-f141" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9e36-ac96-3132-f141" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -2408,13 +2405,13 @@ The target figure is surrounded by psychic energy. The next time it is hit with 
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="80e5-090e-e141-08e9" name="Regenerate" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c07e-b819-cafb-4d9d" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c07e-b819-cafb-4d9d" type="max"/>
           </constraints>
           <profiles>
             <profile id="7adb-5c07-fe66-3ac5" name="Regenerate" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -2423,12 +2420,12 @@ The target figure is surrounded by psychic energy. The next time it is hit with 
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6939-3fb3-687a-2a0b" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6939-3fb3-687a-2a0b" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -2448,13 +2445,13 @@ The activator regains up to 3 points of lost Health.</description>
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="69d3-55d4-4893-2df9" name="Remote Guidance" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1b9-6217-b6ba-caa5" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1b9-6217-b6ba-caa5" type="max"/>
           </constraints>
           <profiles>
             <profile id="3dfe-87bd-1c1a-096b" name="Remote Guidance" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -2463,12 +2460,12 @@ The activator regains up to 3 points of lost Health.</description>
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9d84-3333-57c7-92ea" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9d84-3333-57c7-92ea" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -2488,13 +2485,13 @@ This power may be used on any robot soldier. That robot can always activate in t
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="b85d-0d3a-49a4-0055" name="Remote Firing" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a5d-316f-f254-f890" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a5d-316f-f254-f890" type="max"/>
           </constraints>
           <profiles>
             <profile id="7ace-ee5d-176d-41a2" name="Remote Firing" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -2505,15 +2502,15 @@ This power may be used on any robot soldier. That robot can always activate in t
                       <conditionGroups>
                         <conditionGroup type="and">
                           <conditions>
-                            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1510-fec4-0334-8026" type="notInstanceOf"/>
-                            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9d84-3333-57c7-92ea" type="notInstanceOf"/>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1510-fec4-0334-8026" type="notInstanceOf"/>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9d84-3333-57c7-92ea" type="notInstanceOf"/>
                           </conditions>
                         </conditionGroup>
                       </conditionGroups>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -2533,13 +2530,13 @@ This power allows the user to select one robot in the same crew that is within l
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="af78-062e-404b-2b7c" name="Repair Robot" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d4bd-9327-44f7-2e9a" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d4bd-9327-44f7-2e9a" type="max"/>
           </constraints>
           <profiles>
             <profile id="1154-79bc-cf15-8e0d" name="Repair Robot" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -2548,12 +2545,12 @@ This power allows the user to select one robot in the same crew that is within l
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9d84-3333-57c7-92ea" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9d84-3333-57c7-92ea" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -2573,13 +2570,13 @@ This power restores up to 5 points of lost Health to a target robot within 6”.
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="8f4d-c53a-14f5-f971" name="Restructure Body" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="929d-5ee1-4eca-166c" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="929d-5ee1-4eca-166c" type="max"/>
           </constraints>
           <profiles>
             <profile id="7eb5-8656-a3cb-e2d6" name="Restructure Body" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -2588,12 +2585,12 @@ This power restores up to 5 points of lost Health to a target robot within 6”.
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6939-3fb3-687a-2a0b" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6939-3fb3-687a-2a0b" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -2613,13 +2610,13 @@ The activator gains one of the following traits of its choice: Amphibious, Burro
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="b5ba-3946-005b-2335" name="Quick-Step" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b77-42cc-e6db-2f01" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b77-42cc-e6db-2f01" type="max"/>
           </constraints>
           <profiles>
             <profile id="d032-8e12-deb9-9bb7" name="Quick-Step" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -2630,15 +2627,15 @@ The activator gains one of the following traits of its choice: Amphibious, Burro
                       <conditionGroups>
                         <conditionGroup type="and">
                           <conditions>
-                            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e49-f5d3-e9cd-c200" type="notInstanceOf"/>
-                            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1795-c4e8-6ca2-380b" type="notInstanceOf"/>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e49-f5d3-e9cd-c200" type="notInstanceOf"/>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1795-c4e8-6ca2-380b" type="notInstanceOf"/>
                           </conditions>
                         </conditionGroup>
                       </conditionGroups>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -2658,13 +2655,13 @@ A figure may not make a Power Move when attempting to activate this power. The a
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="be22-d0a1-c5ec-ee03" name="Re-wire Robot" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="991c-be47-054e-fe52" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="991c-be47-054e-fe52" type="max"/>
           </constraints>
           <profiles>
             <profile id="d4ca-3374-e891-5390" name="Re-wire Robot" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -2673,12 +2670,12 @@ A figure may not make a Power Move when attempting to activate this power. The a
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9d84-3333-57c7-92ea" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9d84-3333-57c7-92ea" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -2698,13 +2695,13 @@ Select one robot in the crew. The robot may be given one of the following enhanc
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="2677-eae8-5643-5ca0" name="Suggestion" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bbef-dd29-1da6-0c9d" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bbef-dd29-1da6-0c9d" type="max"/>
           </constraints>
           <profiles>
             <profile id="ec39-e52c-85f9-c111" name="Suggestion" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -2713,15 +2710,15 @@ Select one robot in the crew. The robot may be given one of the following enhanc
                   <conditionGroups>
                     <conditionGroup type="and">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9e36-ac96-3132-f141" type="notInstanceOf"/>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2934-b054-68dc-0468" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9e36-ac96-3132-f141" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2934-b054-68dc-0468" type="notInstanceOf"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
                 </modifier>
                 <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                   <conditions>
-                    <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -2739,13 +2736,13 @@ The target of this power must make an immediate Will Roll (TN16). If it fails, i
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6408-4bdc-a06e-2901" name="Target Designation" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48af-57c2-75d6-8abe" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48af-57c2-75d6-8abe" type="max"/>
           </constraints>
           <profiles>
             <profile id="e07a-e2ab-0ea9-bf0a" name="Target Designation" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -2754,12 +2751,12 @@ The target of this power must make an immediate Will Roll (TN16). If it fails, i
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1510-fec4-0334-8026" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1510-fec4-0334-8026" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -2779,13 +2776,13 @@ For the rest of the battle, this figure receives -2 Fight whenever rolling again
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="cf88-d787-831b-57d4" name="Target Lock" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="66eb-e806-e721-87c2" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="66eb-e806-e721-87c2" type="max"/>
           </constraints>
           <profiles>
             <profile id="80f0-fee4-bc61-6ac6" name="Target Lock" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -2794,12 +2791,12 @@ For the rest of the battle, this figure receives -2 Fight whenever rolling again
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1795-c4e8-6ca2-380b" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1795-c4e8-6ca2-380b" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -2819,13 +2816,13 @@ The activator may make an immediate grenade or grenade launcher attack as a free
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="a6c7-3f11-fa16-5cca" name="Temporary Upgrade" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dfb6-5554-be2d-e40a" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dfb6-5554-be2d-e40a" type="max"/>
           </constraints>
           <profiles>
             <profile id="a3b7-f467-c89a-c86c" name="Temporary Upgrade" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -2834,12 +2831,12 @@ The activator may make an immediate grenade or grenade launcher attack as a free
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1795-c4e8-6ca2-380b" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1795-c4e8-6ca2-380b" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -2859,13 +2856,13 @@ The activator may select one of the following stat increases: +1 Move, +1 Fight,
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="4241-0fe8-c980-267c" name="Toxic Claws" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="09d1-725a-5c33-e965" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="09d1-725a-5c33-e965" type="max"/>
           </constraints>
           <profiles>
             <profile id="5bee-76dd-98eb-dbdc" name="Toxic Claws" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -2874,12 +2871,12 @@ The activator may select one of the following stat increases: +1 Move, +1 Fight,
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6939-3fb3-687a-2a0b" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6939-3fb3-687a-2a0b" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -2899,13 +2896,13 @@ The figure immediately grows a set of indestructible claws. These count as a han
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="df16-ba4d-8a94-d333" name="Toxic Secretion" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b19a-8d44-5422-1a58" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b19a-8d44-5422-1a58" type="max"/>
           </constraints>
           <profiles>
             <profile id="e501-dc94-930c-d00e" name="Toxic Secretion" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -2914,12 +2911,12 @@ The figure immediately grows a set of indestructible claws. These count as a han
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6939-3fb3-687a-2a0b" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6939-3fb3-687a-2a0b" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -2939,13 +2936,13 @@ The activator may select up to two members of their crew, including itself. All 
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="497f-09a6-6e65-efba" name="Transport" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b6bf-2ecd-3904-3961" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b6bf-2ecd-3904-3961" type="max"/>
           </constraints>
           <profiles>
             <profile id="0b68-505d-9ff9-5319" name="Transport" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -2954,12 +2951,12 @@ The activator may select up to two members of their crew, including itself. All 
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8702-3db8-4e88-faf8" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8702-3db8-4e88-faf8" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -2979,13 +2976,13 @@ May target one member of the same crew that is within Line of Sight and 12” fr
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="f283-f16f-00b9-143c" name="Void Blade" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba99-55cf-a583-bde5" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba99-55cf-a583-bde5" type="max"/>
           </constraints>
           <profiles>
             <profile id="52ef-7385-3e3b-9adb" name="Void Blade" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -2994,12 +2991,12 @@ May target one member of the same crew that is within Line of Sight and 12” fr
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2934-b054-68dc-0468" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2934-b054-68dc-0468" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -3019,13 +3016,13 @@ A figure must be carrying a hand weapon in order to use this power. This hand we
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="55bd-2cc0-2ac0-83c0" name="Wall of Force" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ca7-89e9-c896-3d16" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ca7-89e9-c896-3d16" type="max"/>
           </constraints>
           <profiles>
             <profile id="41ad-f691-df22-b2be" name="Wall of Force" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -3034,12 +3031,12 @@ A figure must be carrying a hand weapon in order to use this power. This hand we
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9e36-ac96-3132-f141" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9e36-ac96-3132-f141" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -3059,13 +3056,13 @@ Creates an impenetrable, transparent wall, up to 6” long and 3” high anywher
             </rule>
           </rules>
           <costs>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="96fa-7b92-ea6d-e3d3" name="Beast Call" publicationId="460c-b731-33cf-903c" page="14" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="02ee-bb91-3142-b8ac" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="02ee-bb91-3142-b8ac" type="max"/>
           </constraints>
           <profiles>
             <profile id="1059-d93d-f2be-2d8b" name="Beast Call" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -3074,12 +3071,12 @@ Creates an impenetrable, transparent wall, up to 6” long and 3” high anywher
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a163-ca0d-f3a8-52fa" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a163-ca0d-f3a8-52fa" type="instanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -3098,13 +3095,13 @@ Creates an impenetrable, transparent wall, up to 6” long and 3” high anywher
             </rule>
           </rules>
           <costs>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="1339-ab4d-2387-d90e" name="Crack Shot" publicationId="460c-b731-33cf-903c" page="14" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eed3-b1d3-da15-a659" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eed3-b1d3-da15-a659" type="max"/>
           </constraints>
           <profiles>
             <profile id="74da-8762-d452-09e4" name="Crack Shot" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -3113,12 +3110,12 @@ Creates an impenetrable, transparent wall, up to 6” long and 3” high anywher
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a163-ca0d-f3a8-52fa" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a163-ca0d-f3a8-52fa" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -3137,13 +3134,13 @@ Creates an impenetrable, transparent wall, up to 6” long and 3” high anywher
             </rule>
           </rules>
           <costs>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="0088-0294-0622-32b9" name="Contacts" publicationId="460c-b731-33cf-903c" page="14" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c15-379f-3376-e10b" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c15-379f-3376-e10b" type="max"/>
           </constraints>
           <profiles>
             <profile id="49eb-0ddd-4550-14c6" name="Contacts" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -3152,12 +3149,12 @@ Creates an impenetrable, transparent wall, up to 6” long and 3” high anywher
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="bc20-7fbc-9e6d-b851" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="bc20-7fbc-9e6d-b851" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -3176,13 +3173,13 @@ Creates an impenetrable, transparent wall, up to 6” long and 3” high anywher
             </rule>
           </rules>
           <costs>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="dd52-ba89-a1ca-af94" name="Indifference" publicationId="460c-b731-33cf-903c" page="14" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d519-d4be-da3c-146d" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d519-d4be-da3c-146d" type="max"/>
           </constraints>
           <profiles>
             <profile id="4919-e90b-066e-2c8f" name="Indifference" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -3191,12 +3188,12 @@ Creates an impenetrable, transparent wall, up to 6” long and 3” high anywher
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="bc20-7fbc-9e6d-b851" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="bc20-7fbc-9e6d-b851" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -3215,13 +3212,13 @@ Creates an impenetrable, transparent wall, up to 6” long and 3” high anywher
             </rule>
           </rules>
           <costs>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="4a2a-c192-d2bd-a1f5" name="Inspiring" publicationId="460c-b731-33cf-903c" page="14" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ca7-c179-3754-4b5d" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ca7-c179-3754-4b5d" type="max"/>
           </constraints>
           <profiles>
             <profile id="a4c3-4bbb-4fef-392e" name="Inspiring" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -3230,12 +3227,12 @@ Creates an impenetrable, transparent wall, up to 6” long and 3” high anywher
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="bc20-7fbc-9e6d-b851" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="bc20-7fbc-9e6d-b851" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -3254,13 +3251,13 @@ Creates an impenetrable, transparent wall, up to 6” long and 3” high anywher
             </rule>
           </rules>
           <costs>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="89bf-20cf-e3de-f4e8" name="Investments" publicationId="460c-b731-33cf-903c" page="15" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb26-3037-f511-2db6" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb26-3037-f511-2db6" type="max"/>
           </constraints>
           <profiles>
             <profile id="d7a3-676b-019f-d640" name="Investments" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -3269,12 +3266,12 @@ Creates an impenetrable, transparent wall, up to 6” long and 3” high anywher
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="bc20-7fbc-9e6d-b851" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="bc20-7fbc-9e6d-b851" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -3293,13 +3290,13 @@ Creates an impenetrable, transparent wall, up to 6” long and 3” high anywher
             </rule>
           </rules>
           <costs>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6415-1694-4988-4c9a" name="Study Prey" publicationId="460c-b731-33cf-903c" page="15" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6239-3e2e-4af4-0011" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6239-3e2e-4af4-0011" type="max"/>
           </constraints>
           <profiles>
             <profile id="9d40-71f1-1b7e-0936" name="Study Prey" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -3308,12 +3305,12 @@ Creates an impenetrable, transparent wall, up to 6” long and 3” high anywher
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a163-ca0d-f3a8-52fa" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a163-ca0d-f3a8-52fa" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -3332,13 +3329,13 @@ Creates an impenetrable, transparent wall, up to 6” long and 3” high anywher
             </rule>
           </rules>
           <costs>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6a02-a5d8-c678-46b2" name="Weapon Maintenance" publicationId="460c-b731-33cf-903c" page="15" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a61b-8283-f7a6-36a7" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a61b-8283-f7a6-36a7" type="max"/>
           </constraints>
           <profiles>
             <profile id="2000-2dcd-3bb7-be18" name="Weapon Maintenance" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
@@ -3347,12 +3344,12 @@ Creates an impenetrable, transparent wall, up to 6” long and 3” high anywher
                   <modifiers>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a163-ca0d-f3a8-52fa" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a163-ca0d-f3a8-52fa" type="notInstanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -3371,8 +3368,8 @@ Creates an impenetrable, transparent wall, up to 6” long and 3” high anywher
             </rule>
           </rules>
           <costs>
-            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0.0"/>
-            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0.0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -3383,76 +3380,76 @@ Creates an impenetrable, transparent wall, up to 6” long and 3” high anywher
           <entryLinks>
             <entryLink id="0de9-c045-c762-238c" name="Unarmed" hidden="false" collective="false" import="true" targetId="f80d-224c-77b3-3bc8" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5de7-260b-3f6a-098f" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5de7-260b-3f6a-098f" type="max"/>
               </constraints>
             </entryLink>
             <entryLink id="a7a0-b872-2204-43d0" name="Knife" hidden="false" collective="false" import="true" targetId="cb09-0362-58dc-6b9d" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f598-e209-0577-affa" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f598-e209-0577-affa" type="max"/>
               </constraints>
             </entryLink>
             <entryLink id="56a7-6741-482f-63d3" name="Hand Weapon" hidden="false" collective="false" import="true" targetId="751f-ebe1-9a04-524e" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="07c0-40ec-19ca-9083" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="07c0-40ec-19ca-9083" type="max"/>
               </constraints>
               <costs>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="1.0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="1"/>
               </costs>
             </entryLink>
             <entryLink id="3086-2384-9c00-3010" name="Pistol" hidden="false" collective="false" import="true" targetId="4039-8fee-a371-8311" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b9f-c86e-2635-f553" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b9f-c86e-2635-f553" type="max"/>
               </constraints>
               <costs>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="1.0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="1"/>
               </costs>
             </entryLink>
             <entryLink id="938d-d3a7-8593-85f7" name="Carbine" hidden="false" collective="false" import="true" targetId="5458-bb3d-f66c-0c0f" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="117a-54d8-bec8-43da" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="117a-54d8-bec8-43da" type="max"/>
               </constraints>
               <costs>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="2.0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="2"/>
               </costs>
             </entryLink>
             <entryLink id="bcda-6a24-4070-acce" name="Shotgun" hidden="false" collective="false" import="true" targetId="1075-090d-31e0-ad87" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a5bc-6c61-641b-867d" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a5bc-6c61-641b-867d" type="max"/>
               </constraints>
               <costs>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="2.0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="2"/>
               </costs>
             </entryLink>
             <entryLink id="f804-72c1-79c6-e52c" name="Flamethrower" hidden="false" collective="false" import="true" targetId="4fcb-337a-cabb-7e51" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="37df-8704-b50c-70d4" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="37df-8704-b50c-70d4" type="max"/>
               </constraints>
               <costs>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="2.0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="2"/>
               </costs>
             </entryLink>
             <entryLink id="7fe5-e5da-1e4b-c15b" name="Grenade (Frag/Smoke)" hidden="false" collective="false" import="true" targetId="ccbe-994d-4323-a5b7" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d3ed-68b1-fae7-fa68" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d3ed-68b1-fae7-fa68" type="max"/>
               </constraints>
               <costs>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="1.0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="1"/>
               </costs>
             </entryLink>
             <entryLink id="c858-3212-f0dd-060a" name="Rapid Fire" hidden="false" collective="false" import="true" targetId="5e6a-f427-bc23-ed0a" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e16d-dac9-d940-8cef" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e16d-dac9-d940-8cef" type="max"/>
               </constraints>
               <costs>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="3.0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="3"/>
               </costs>
             </entryLink>
             <entryLink id="510e-501e-c555-881b" name="Grenade Launcher" hidden="false" collective="false" import="true" targetId="97aa-31b1-6492-ac84" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8706-e94f-10fe-8c80" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8706-e94f-10fe-8c80" type="max"/>
               </constraints>
               <costs>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="3.0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="3"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -3461,66 +3458,76 @@ Creates an impenetrable, transparent wall, up to 6” long and 3” high anywher
           <entryLinks>
             <entryLink id="aee1-8fbf-36ec-b56f" name="Deck" hidden="false" collective="false" import="true" targetId="cb72-75b1-00d6-d034" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="512a-14c7-fc75-81e4" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="512a-14c7-fc75-81e4" type="max"/>
               </constraints>
               <costs>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="1.0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="1"/>
               </costs>
             </entryLink>
             <entryLink id="8ca3-a0ac-2969-df20" name="Filter Mask" hidden="false" collective="false" import="true" targetId="d820-8ec9-e4eb-df4a" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6514-8b13-6696-1a0c" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6514-8b13-6696-1a0c" type="max"/>
               </constraints>
               <costs>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="1.0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="1"/>
               </costs>
             </entryLink>
             <entryLink id="f48b-4df0-b3ea-4402" name="Medic Kit" hidden="false" collective="false" import="true" targetId="2579-e6e7-e7dc-73c1" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c703-1745-b053-e77d" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c703-1745-b053-e77d" type="max"/>
               </constraints>
               <costs>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="1.0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="1"/>
               </costs>
             </entryLink>
             <entryLink id="80f3-aa0a-b2d0-1856" name="Picks" hidden="false" collective="false" import="true" targetId="84b2-39a3-0985-b603" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="70c1-e872-2068-3cb6" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="70c1-e872-2068-3cb6" type="max"/>
               </constraints>
               <costs>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="1.0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="1"/>
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="94b5-2c9d-faa7-c483" name="Armour" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bbb2-b7d3-4581-ff26" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bbb2-b7d3-4581-ff26" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="68a9-9ba3-12d2-ca3c" name="Light Armour" hidden="false" collective="false" import="true" targetId="2c5f-174f-fa1f-26c7" type="selectionEntry">
               <costs>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="1.0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="1"/>
               </costs>
             </entryLink>
             <entryLink id="6ca0-4667-70a7-c7a1" name="Heavy Armour" hidden="false" collective="false" import="true" targetId="b824-fc04-4c55-b49e" type="selectionEntry">
               <costs>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="1.0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="1"/>
               </costs>
             </entryLink>
             <entryLink id="43ae-6593-42d1-0c8e" name="Combat Armour" hidden="false" collective="false" import="true" targetId="ea4f-6372-4af1-e30b" type="selectionEntry">
               <costs>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="2.0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="2"/>
               </costs>
             </entryLink>
             <entryLink id="2175-eec5-7cd9-5b2d" name="Shield" hidden="false" collective="false" import="true" targetId="5cee-33b2-65b6-c8a0" type="selectionEntry">
               <costs>
-                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="1.0"/>
+                <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="1"/>
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup name="Core Powers" id="8f77-0290-5b40-2a4c" hidden="false">
+      <entryLinks>
+        <entryLink import="true" name="Powers" hidden="false" id="3c58-2a49-656f-f3e1" type="selectionEntryGroup" targetId="7753-4141-f613-ae54"/>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup name="Other Powers" id="d187-4aa6-4f21-7b77" hidden="false">
+      <entryLinks>
+        <entryLink import="true" name="Powers" hidden="false" id="791d-dd71-aa6e-63a6" type="selectionEntryGroup" targetId="7753-4141-f613-ae54"/>
+      </entryLinks>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>

--- a/Stargrave.gst
+++ b/Stargrave.gst
@@ -3526,11 +3526,6 @@ Creates an impenetrable, transparent wall, up to 6” long and 3” high anywher
         </selectionEntryGroup>
       </selectionEntryGroups>
     </selectionEntryGroup>
-    <selectionEntryGroup name="Other Powers" id="d187-4aa6-4f21-7b77" hidden="false">
-      <entryLinks>
-        <entryLink import="true" name="Powers" hidden="false" id="791d-dd71-aa6e-63a6" type="selectionEntryGroup" targetId="7753-4141-f613-ae54"/>
-      </entryLinks>
-    </selectionEntryGroup>
     <selectionEntryGroup id="4da1-d546-eaec-5450" name="Core Powers" hidden="false" collective="false" import="true">
       <selectionEntries>
         <selectionEntry id="ff98-6c68-7984-3719" name="Adrenaline Surge" hidden="true" collective="false" import="true" type="upgrade">
@@ -6408,6 +6403,2893 @@ Creates an impenetrable, transparent wall, up to 6” long and 3” high anywher
           </profiles>
           <rules>
             <rule id="0c42-716d-91c6-527f" name="Weapon Maintenance" hidden="false">
+              <description>Select one carbine, shotgun, or pistol. That weapon becomes indestrctible, gains +1 damage, and never jams (Shooting Rolls of &apos;1&apos; trigger no special effects), for the duration of the next game.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="8b97-db29-9e0e-bce4" name="Other Powers" hidden="false" collective="false" import="true">
+      <selectionEntries>
+        <selectionEntry id="f3fe-b3fa-6d39-0285" name="Adrenaline Surge" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="733a-65d5-5c0c-867f" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="abda-f984-4451-46e3" name="Adrenaline Surge" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6939-3fb3-687a-2a0b" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">12</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">2</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Self Only</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="a526-46e3-8407-b53e" name="Adrenaline Surge" hidden="false">
+              <description>Self Only
+This figure immediately gains an additional action during this activation, and an additional action in their next activation as well.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="6939-3fb3-687a-2a0b" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="3d36-c90e-1d17-ec56" name="Antigravity Projection" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1c3-dff4-bba1-12d0" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="83e2-9a0b-c9bf-091c" name="Antigravity Projection" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8702-3db8-4e88-faf8" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="9407-a2e1-cdf9-8d20" name="Antigravity Projection" hidden="false">
+              <description>Line of Sight
+The target figure gains the Levitate attribute (page 156) for the rest of the game.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8702-3db8-4e88-faf8" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="e07b-c117-c6f8-7d17" name="Armour Plates" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ddf-31ef-147b-9d7e" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="be35-106e-54f4-08a1" name="Armour Plates" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6939-3fb3-687a-2a0b" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">2</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Self Only or Out of Game (B)</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="8ffb-c63f-28cd-b7a9" name="Armour Plates" hidden="false">
+              <description>Self Only or Out of Game (B)
+The figure gains +2 Armour. This power may not be used if the figure is already wearing combat armour.
+This power can be used Out of Game (B), in which case the activating figure starts the game at -2 Damage to represent the Strain.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="6939-3fb3-687a-2a0b" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="1d48-fee6-388e-6b12" name="Armoury" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e9fb-74c2-cda1-dba3" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="30ce-a13e-b7ad-f4ea" name="Armoury" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1510-fec4-0334-8026" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Out of Game (B)</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="d281-e368-4cbd-f621" name="Armoury" hidden="false">
+              <description>Out of Game (B)
+The crew can field one suit of combat armour without having to pay is normal upkeep cost.
+Alternatively, one standard (not Advanced Technology) pistol, carbine, or shotgun may be given a +1 Damage modifier for the next game only.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="1510-fec4-0334-8026" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="76d4-0570-2af9-9bfd" name="Bait and Switch" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd2d-83ae-f98d-333e" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="f4e4-f846-b709-d863" name="Bait and Switch" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e49-f5d3-e9cd-c200" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">12</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">2</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="4bf1-5df3-f1a9-bed6" name="Bait and Switch" hidden="false">
+              <description>Line of Sight
+This power may only be used against a soldier carrying a loot token. That figure must make an immediate Will Roll (TN14). If failed, the figure immediately drops the loot token and the  activator may move it up to 4” in any direction.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8e49-f5d3-e9cd-c200" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="c001-f07f-3005-84ac" name="Break Lock" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94a3-5850-bb50-fe93" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="23eb-8e6e-a308-ba4e" name="Break Lock" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9e36-ac96-3132-f141" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">12</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="e4c4-b3eb-e513-4722" name="Break Lock" hidden="false">
+              <description>Line of Sight
+Immediately unlocks one physical-loot counter.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="9e36-ac96-3132-f141" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="bcb4-c48b-08b2-7a1d" name="Bribe" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1749-2fda-f986-4a1c" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="176c-a768-94f0-8906" name="Bribe" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e49-f5d3-e9cd-c200" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">14</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Out of Game (B)</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="97fc-1f06-eeb2-4e71" name="Bribe" hidden="false">
+              <description>Out of Game (B)
+If successful, place one bribe token next to the table and make your opponent aware of it. At any point of the game, when your opponent declares that a soldier (not a captain or first mate) is making a Shooting attack, but before the dice are rolled, you may play your bribe token. The Shooting attack automatically misses, and no dice are rolled. No crew may use more than one bribe token in any game.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8e49-f5d3-e9cd-c200" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="36cb-a02a-3d29-3ec2" name="Camouflage" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="44df-ab8f-899c-6aa2" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="c30f-06bc-3b94-010f" name="Camouflage" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1795-c4e8-6ca2-380b" type="notInstanceOf"/>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6939-3fb3-687a-2a0b" type="notInstanceOf"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">2</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Self Only</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="35d8-70fa-59e7-076b" name="Camouflage" hidden="false">
+              <description>Self Only
+No figure may draw line of sight to this figure if it is more than 12” away. In addition, it gains +2 Fight when rolling against Shooting attacks from pistol, carbine, shotgun, or rapid-fire attacks. This power is cancelled if the figure becomes stunned.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="6939-3fb3-687a-2a0b" shared="true"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="1795-c4e8-6ca2-380b" shared="true"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="12c3-5257-e3a9-8e59" name="Cancel Power" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d613-cca5-6dfd-af90" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="e198-db0c-8d2c-7c9b" name="Cancel Power" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e49-f5d3-e9cd-c200" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">12</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="0f84-e24a-61e5-6fdb" name="Cancel Power" hidden="false">
+              <description>Line of Sight
+Immediately cancels all effects of one ongoing Line of Sight power. It has no effect on powers with other designations.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8e49-f5d3-e9cd-c200" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="729a-e513-5d90-3318" name="Command" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e531-a3ef-4a4b-b4f0" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="0e0d-ecde-0f51-5fda" name="Command" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1510-fec4-0334-8026" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="35e3-e076-3b07-cec8" name="Command" hidden="false">
+              <description>Line of Sight
+Select one member of the crew that is in line of sight. That figure now activates in the current player’s phase this turn. This power may not be used on a figure that has already activated in this turn.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="1510-fec4-0334-8026" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="04ea-480c-6bd5-9124" name="Concealed Firearm" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4028-17d9-2a9d-cf7e" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="8d08-3b11-7b34-988f" name="Concealed Firearm" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e49-f5d3-e9cd-c200" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Self Only</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="ecff-cbbb-f6eb-c2ee" name="Concealed Firearm" hidden="false">
+              <description>Self Only
+This power may only be used while a figure is in combat. The figure may make one +5 Shooting attack against any other figure in the combat. Do not randomize the target of the attack, even if there are multiple figures in the combat. If this attack damages the target, it is automatically pushed back 1” and stunned, even if the attack did less than 4 Damage.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8e49-f5d3-e9cd-c200" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="2ddd-cca7-c48f-18dc" name="Control Animal" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="082a-f327-6848-07bd" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="3b39-5819-b125-75ca" name="Control Animal" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2934-b054-68dc-0468" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="a9e5-cf75-25fd-d827" name="Control Animal" hidden="false">
+              <description>Line of Sight
+This power may only be used against uncontrolled animals. The target animal must make an immediate Will Roll (TN16) or become a temporary member of the same crew as the activator. Each figure with this power may only have one animal under control at any time. They may cancel this power at any time as a free action.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="2934-b054-68dc-0468" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="19df-bda6-0c08-6aec" name="Control Robot" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e4bf-6d2c-1b76-9c20" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="0a1e-b1ff-bdf7-5915" name="Control Robot" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9d84-3333-57c7-92ea" type="notInstanceOf"/>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1795-c4e8-6ca2-380b" type="notInstanceOf"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="247e-dc55-0d00-3050" name="Control Robot" hidden="false">
+              <description>Line of Sight
+Select one robot in line of sight. That robot must make an immediate Will Roll (TN15). If it succeeds, nothing happens. If it fails, it immediately joins the crew of activator as a temporary member. The controlled robot may make a new Will Roll (TN15) after each of its activations. If it succeeds this power is canceled and the robot immediately reverts to its previous allegiance. A figure with this power may only have one robot under control at any time. They may cancel this power at any time as a free action.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="1795-c4e8-6ca2-380b" shared="true" includeChildSelections="false"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="9d84-3333-57c7-92ea" shared="true" includeChildSelections="false"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="fd47-3426-9491-31c8" name="Coordinated Fire" hidden="false" collective="false" import="true" type="upgrade">
+          <comment>Activation: 10 / Strain: 0 / Line of Sight
+The target member of the crew receives +1 Shoot for
+the duration of the game. This may not take a figure
+above +5 Shoot. A figure may only benefit from one
+Coordinated Fire Power at a time.</comment>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="214a-77b8-8cbd-6901" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="bfa8-5e6c-a87c-97c2" name="Coordinated Fire" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1510-fec4-0334-8026" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="d179-6534-2216-052a" name="Coordinated Fire" hidden="false">
+              <description>Line of Sight
+The target member of the crew receives +1 Shoot for the duration of the game. This may not take a figure above +5 Shoot. A figure may only benefit from one Coordinated Fire Power at a time.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="1510-fec4-0334-8026" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="052a-2688-a923-3f7c" name="Create Robot" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="505f-a8e1-2565-7227" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="38d1-dbb7-769e-e8ce" name="Create Robot" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9d84-3333-57c7-92ea" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">14</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Out of Game (A)</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="a7d4-a647-0d5b-f8c0" name="Create Robot" hidden="false">
+              <description>Out of Game (A)
+The player may immediately add one robot soldier to their crew for no cost. This soldier can be of any type except Armoured Trooper, but the crew is still subject to the normal limitation on soldiers and specialist soldiers.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="9d84-3333-57c7-92ea" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="2ba1-0f6e-3a75-341f" name="Dark Energy" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d94f-d2eb-8346-bf9a" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="406f-941c-c648-e070" name="Dark Energy" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2934-b054-68dc-0468" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="2ab9-66c4-8988-3b74" name="Dark Energy" hidden="false">
+              <description>Line of Sight
+The figure makes a +5 Shooting attack against any target within 12”. This attack ignores any armour worn by a figure (so subtract a figure’s armour 1modifier from their armour). Increase this attack to +7 against robots. If this attack targets a figure in combat, do not randomize the target, it can only hit the intended target. (Armour Interference).</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="2934-b054-68dc-0468" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="2ee1-51d4-717b-e60e" name="Data Jump" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e89-5b15-c460-adcd" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="a0b8-6b7f-2225-6196" name="Data Jump" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8702-3db8-4e88-faf8" type="notInstanceOf"/>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e49-f5d3-e9cd-c200" type="notInstanceOf"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="f99d-bb77-0366-872c" name="Data Jump" hidden="false">
+              <description>Line of Sight
+This power may only target a member of the same warband that is carrying a data-loot token. The player may immediately move the data-loot token carried by that figure to another member of the crew, provided both are in line of sight of the activator and within 8” of one another.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8e49-f5d3-e9cd-c200" shared="true" includeChildSelections="false"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8702-3db8-4e88-faf8" shared="true" includeChildSelections="false"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="90dc-d2b3-ee01-4e27" name="Data Knock" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb41-0354-0dbc-2cc4" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="06ec-688d-721e-fb9d" name="Data Knock" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8702-3db8-4e88-faf8" type="notInstanceOf"/>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1795-c4e8-6ca2-380b" type="notInstanceOf"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">12</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="53fd-8e70-6a0d-651f" name="Data Knock" hidden="false">
+              <description>Line of Sight
+Immediately unlocks one data-loot counter.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="1795-c4e8-6ca2-380b" shared="true" includeChildSelections="false"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8702-3db8-4e88-faf8" shared="true" includeChildSelections="false"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="09f4-eb39-3716-3595" name="Data Skip" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a5a5-dd8c-720e-1615" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="3f25-81a9-8704-22ce" name="Data Skip" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8702-3db8-4e88-faf8" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">12</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">2</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="0e90-9c91-c45f-cd8b" name="Data Skip" hidden="false">
+              <description>Line of Sight
+This power targets an unlocked data-loot token or a figure carrying such a token that is within 12”. If the token is not being carried, the activator may move the data-loot token 4” in any direction. If a figure is carrying the token, then that figure must make a Will Roll (TN16). If failed, the activator may move the data-loot token up to 4” in any direction. Either way, the token remains unlocked.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8702-3db8-4e88-faf8" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="3dfc-b42c-60ad-d5a6" name="Destroy Weapon" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="550c-4591-91df-84f8" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="d785-1cda-cd79-4444" name="Destroy Weapon" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9e36-ac96-3132-f141" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">12</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">2</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="72e4-e718-ec8f-10d9" name="Destroy Weapon" hidden="false">
+              <description>Line of Sight
+This power may be used against any figure within 12”. The activator may choose one weapon carried by that figure to be destroyed, except indestructible weapons. This weapon is replaced for free after the game. (Armour Interference).</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="9e36-ac96-3132-f141" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="42f1-a8f2-5b64-d0e2" name="Drone" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e75-d86d-96dd-9bf7" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="7a2f-c0a0-0894-a257" name="Drone" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8702-3db8-4e88-faf8" type="notInstanceOf"/>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9d84-3333-57c7-92ea" type="notInstanceOf"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Touch</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="d9c2-9702-8972-6d63" name="Drone" hidden="false">
+              <description>Touch
+Place a drone next to the activator (see Chapter Six: Bestiary, page 144). This drone counts as a temporary member of the crew, and may activate and move as normal. For the rest of the game, the figure may draw line of sight from the drone, instead of the figure, when using a power. This includes using Touch powers. A figure may only have one active drone at a time.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="9d84-3333-57c7-92ea" shared="true" includeChildSelections="false"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8702-3db8-4e88-faf8" shared="true" includeChildSelections="false"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="37fc-8431-e96f-c0f9" name="Electromagnetic Pulse" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e818-3d35-19b5-92ad" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="f055-aff6-494e-491d" name="Electromagnetic Pulse" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8702-3db8-4e88-faf8" type="notInstanceOf"/>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9d84-3333-57c7-92ea" type="notInstanceOf"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="af95-175e-f068-55f1" name="Electromagnetic Pulse" hidden="false">
+              <description>Line of Sight
+If targeted against a robot, that robot must make an immediate Will Roll (TN18). If it fails, it receives no actions the next time it activates.
+If targeted against a non-robot figure, all firearms carried by that figure immediately jam as though they had rolled a 1 on a Shooting attack. Additionally, the weapon suffers a -1 Damage modifier for the rest of the game. A weapon can be jammed in multiple turns through the use of this power, but the Damage modifier only applies the first time.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="9d84-3333-57c7-92ea" shared="true" includeChildSelections="false"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8702-3db8-4e88-faf8" shared="true" includeChildSelections="false"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="260e-7d4a-bcc5-f8bd" name="Energy Shield" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="024e-c818-d3d9-46c1" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="97d7-b525-d000-74ab" name="Energy Shield" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1510-fec4-0334-8026" type="notInstanceOf"/>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1795-c4e8-6ca2-380b" type="notInstanceOf"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Self Only</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="d984-d56d-77e2-021b" name="Energy Shield" hidden="false">
+              <description>Self Only
+A small energy shield forms around the user. This shield absorbs the next 3 points of Damage from any Shooting attack that would injure the activator. Once 3 points of Damage have been absorbed, the power is cancelled.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="1795-c4e8-6ca2-380b" shared="true" includeChildSelections="false"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="1510-fec4-0334-8026" shared="true" includeChildSelections="false"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="9ef7-7848-4cab-3310" name="Fling" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f89c-8502-a716-0e27" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="795e-9816-0741-612e" name="Fling" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6939-3fb3-687a-2a0b" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">8</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Self Only or Touch</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="2ea2-23aa-9394-c261" name="Fling" hidden="false">
+              <description>Self Only or Touch
+This power can be used in two ways. The activator may use it while standing within 1” of a member of their crew, in which case they may immediately move that crewmember 6” in any
+direction, including up. However, the figure that was moved is immediately stunned. Alternatively, it can be used while in combat against a specific enemy figure. The target figure must
+make an immediate Fight Roll (TN16). If it fails, the activator may move the target figure up to 6” in any horizontal direction. The figure takes no Damage (unless there is another reason it would, such as falling), but is stunned. This power may not be used on any figure that has the Large attribute.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="6939-3fb3-687a-2a0b" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="6f62-a19d-1383-103e" name="Fortune" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1094-0c91-71fd-faac" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="efad-3102-3359-d581" name="Fortune" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1510-fec4-0334-8026" type="notInstanceOf"/>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e49-f5d3-e9cd-c200" type="notInstanceOf"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">12</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Self Only</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="8f49-d8ca-6ff0-1691" name="Fortune" hidden="false">
+              <description>Self Only
+Place a fortune token either next to the figure or on your crew sheet next to the figure’s entry. At any point the player may discard this token to reroll a Combat Roll, Shooting Roll, or Stat Roll made by that figure. If used, the figure must take the result of the reroll, they cannot choose to take the original roll. No figure may have more than one fortune token at one time.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8e49-f5d3-e9cd-c200" shared="true" includeChildSelections="false"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="1510-fec4-0334-8026" shared="true" includeChildSelections="false"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="f0ba-e566-b3c9-5617" name="Haggle" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f686-128f-e4ca-ffcf" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="8e22-3365-bb27-4674" name="Haggle" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e49-f5d3-e9cd-c200" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Out of Game (A)</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="f9a4-c8e6-342e-5103" name="Haggle" hidden="false">
+              <description>Out of Game (A)
+This power may be used whenever the crew sells anything. The crew receives 20% more than the usual selling price. This power may only be used on the sale of one item after each game.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8e49-f5d3-e9cd-c200" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="5231-bb05-13ae-4719" name="Heal" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="92b0-e169-2c90-f707" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="0926-a0ef-e149-e8ff" name="Heal" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2934-b054-68dc-0468" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="d9f3-6237-be96-e515" name="Heal" hidden="false">
+              <description>Line of Sight
+This power restores up to 5 points of lost Health to a target figure within 6”. This power cannot take a figure above its starting Health. This power has no effect on robots. (Armour  Interference).</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="2934-b054-68dc-0468" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="c05b-d2d1-8205-7114" name="Holographic Wall" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d8d-1cd6-bcc5-66f6" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="a3cb-ea78-f011-2079" name="Holographic Wall" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8702-3db8-4e88-faf8" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="a895-4c31-5d5d-b0f5" name="Holographic Wall" hidden="false">
+              <description>Line of Sight
+Creates a holographic wall 6” long and 3” high. No line of sight may be drawn through this wall. Figures may move through the wall as though it is not there. At the end of each turn, after the turn in which the wall is placed, roll a die. On a 1–4 the holograph fails, and the wall is removed.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8702-3db8-4e88-faf8" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="5683-caec-d469-7e4a" name="Life Leach" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2053-de48-89ac-1f14" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="3734-5467-7da9-8eb2" name="Life Leach" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2934-b054-68dc-0468" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="54c9-cbc4-1d98-6163" name="Life Leach" hidden="false">
+              <description>Line of Sight
+The target must make an immediately Will Roll (TN15). If failed the target loses 3 Health and the figure using the power regains 3 Health. This may not take a figure above its starting Health. This power cannot be used against robots. A figure may use this power on a member of their own crew, but if so, that figure is immediately removed from the crew sheet
+and counts as an uncontrolled figure for the rest of the game. (Armour Interference).</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="2934-b054-68dc-0468" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="a0cb-27b5-8de7-eb3a" name="Lift" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ce6-c35c-5e14-dbe6" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="466e-70df-ab07-2d03" name="Lift" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9e36-ac96-3132-f141" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="52b9-b19d-3d3c-4f9c" name="Lift" hidden="false">
+              <description>Line of Sight
+Immediately move one member of the same crew that is in line of sight 6” in any direction, including vertically. If this leaves the figure hanging above the ground, it immediately drops to the ground, but takes no Damage. The figure that is moved cannot take any additional actions this turn, though may have taken actions previously this turn. This may not move a figure off the table. (Armour Interference).</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="9e36-ac96-3132-f141" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="4966-9177-41e2-66e5" name="Mystic Trance" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="57dd-90c0-c3d5-118e" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="6360-cb78-1490-3566" name="Mystic Trance" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2934-b054-68dc-0468" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">8</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Out of Game (B)</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="60d1-7610-505e-6c43" name="Mystic Trance" hidden="false">
+              <description>Out of Game (B)
+If successfully activated, the figure may attempt to use one of their other powers before the first Initiative Roll as if it was an Out of Game (B) power. No power that targets a point on the table or an enemy figure can be used with Mystic Trance.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="2934-b054-68dc-0468" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="0fc5-abe0-2d1e-eb38" name="Power Spike" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a0e-44b0-2401-8c18" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="d5bd-7da9-f9de-e0d1" name="Power Spike" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1510-fec4-0334-8026" type="notInstanceOf"/>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1795-c4e8-6ca2-380b" type="notInstanceOf"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">8</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Self Only</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="09dd-f5ad-87ef-ef31" name="Power Spike" hidden="false">
+              <description>Self Only
+The next time this figure makes a Shooting attack with a carbine, pistol, or shotgun, the shot does +3 Damage. This is cumulative with other damage modifiers for the weapon. For example, the total modifier would +4 in the case of a shotgun (+3 from Power Spike and +1 from the Shotgun).</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="1795-c4e8-6ca2-380b" shared="true" includeChildSelections="false"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="1510-fec4-0334-8026" shared="true" includeChildSelections="false"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="ed05-19b1-e8ba-234c" name="Psionic Fire" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3357-dbf7-c1fd-0b85" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="e2a3-4e57-2724-c02f" name="Psionic Fire" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9e36-ac96-3132-f141" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Self Only</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="0ebd-9ed4-bf0a-573e" name="Psionic Fire" hidden="false">
+              <description>Self Only
+The activator should place two flamethrower templates as thought the figure had just made a flamethrower attack. These templates may be touching, but may not overlap. Every figure touching a template immediately suffers a +3 flamethrower attack (see page 32). Figures only suffer one attack even if touching both templates. (Armour Interference).</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="9e36-ac96-3132-f141" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="1e20-7861-275b-5d18" name="Pull" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8aba-ca5f-b791-318c" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="3f30-3ea9-a84b-5479" name="Pull" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9e36-ac96-3132-f141" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">12</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="5917-fd5d-1395-1d8c" name="Pull" hidden="false">
+              <description>Line of Sight
+The target figure must make a Will Roll (TN16). If it fails, move that figure up to 6” in any horizontal direction. This may not move a figure over terrain more than 0.5” high. If this moves them off terrain that is above the ground, they fall and take Damage as normal. (Armour Interference).</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="9e36-ac96-3132-f141" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="18be-e58b-ee6c-acd2" name="Puppet Master" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a43d-2c7e-3100-b024" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="601d-9a64-81df-c678" name="Puppet Master" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2934-b054-68dc-0468" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">12</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">2</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Touch</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="e936-3c59-8e90-647b" name="Puppet Master" hidden="false">
+              <description>Touch
+Choose one non-robot member of the crew that has been reduced to 0 Health during the game. That soldier returns to the table, adjacent to the figure activating this power. The soldier has 1 Health and counts as wounded. They are treated as a normal soldier in every other way. Any given soldier may only be returned to the table once each game through the use of Puppet Master. (Armour Interference).</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="2934-b054-68dc-0468" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="14ee-79e3-9ad0-0737" name="Psychic Shield" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c2eb-bad7-da39-8b36" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="102a-6ebd-8205-1bf9" name="Psychic Shield" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9e36-ac96-3132-f141" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">2</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="381b-0c0b-a3ec-a55a" name="Psychic Shield" hidden="false">
+              <description>Line of Sight
+The target figure is surrounded by psychic energy. The next time it is hit with a Shooting attack that causes Damage of any amount, halve that Damage (rounding down), and then the power is cancelled. It this figure is ever in combat, this power is immediately cancelled. If the figure also has an active Energy Shield, deduct then 3 points of Damage for it first, then halve the remaining for the Psychic Shield. (Armour Interference).</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="9e36-ac96-3132-f141" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="c98e-e206-1795-29b2" name="Regenerate" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b22b-3266-7a83-0a14" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="66ff-f735-84fb-868b" name="Regenerate" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6939-3fb3-687a-2a0b" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">8</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Self Only</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="e45f-f5b5-e8f7-bb8e" name="Regenerate" hidden="false">
+              <description>Self Only
+The activator regains up to 3 points of lost Health.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="6939-3fb3-687a-2a0b" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="a56a-4321-9dd4-433c" name="Remote Guidance" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7634-9372-222a-99a0" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="a185-e67d-8b78-6e49" name="Remote Guidance" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9d84-3333-57c7-92ea" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Out of Game (B) or Touch</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="087d-534b-8f8d-ca64" name="Remote Guidance" hidden="false">
+              <description>Out of Game (B) or Touch
+This power may be used on any robot soldier. That robot can always activate in the same phase as the activator, even if it is not within 3”. The player is still limited to a maximum of three soldiers activating in either the Captain or First Mate Phase. An activator may only use Remote Guidance on one robot at a time.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="9d84-3333-57c7-92ea" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="5ded-3218-bcaa-0096" name="Remote Firing" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="67fb-f2c1-2dd9-ffc2" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="473f-974c-e130-1501" name="Remote Firing" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1510-fec4-0334-8026" type="notInstanceOf"/>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9d84-3333-57c7-92ea" type="notInstanceOf"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="f44e-e8e6-2f8e-ceaa" name="Remote Firing" hidden="false">
+              <description>Line of Sight
+This power allows the user to select one robot in the same crew that is within line of sight. That robot makes an immediate +3 Shooting attack against any legal target within 12”. This attack does not count as the robot’s activation, nor does it cost the robot an action.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="9d84-3333-57c7-92ea" shared="true" includeChildSelections="false"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="1510-fec4-0334-8026" shared="true" includeChildSelections="false"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="b44a-082e-5c9c-51ea" name="Repair Robot" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ec2-b62b-ec90-911e" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="5607-97dd-dba6-5641" name="Repair Robot" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9d84-3333-57c7-92ea" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="af60-9d8a-5c92-854c" name="Repair Robot" hidden="false">
+              <description>Line of Sight
+This power restores up to 5 points of lost Health to a target robot within 6”. This power cannot take a figure above its starting Health.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="9d84-3333-57c7-92ea" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="1739-4c97-bbd2-2d99" name="Restructure Body" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="44b7-666b-57dc-2550" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="077b-51a7-d78f-7b66" name="Restructure Body" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6939-3fb3-687a-2a0b" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Self Only or Out of Game (B)</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="12a5-c6e4-0880-360a" name="Restructure Body" hidden="false">
+              <description>Self Only or Out of Game (B)
+The activator gains one of the following traits of its choice: Amphibious, Burrowing, Expert Climber, Immune to Critical Hits, Immune to Toxins, or Never Wounded. It may only gain one of these traits at a time, but can change the attribute from one to another with an additional use of the power.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="6939-3fb3-687a-2a0b" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="0df2-c928-67a2-d18a" name="Quick-Step" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="059e-9573-0c8c-2a27" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="cd97-e4a1-0dec-3373" name="Quick-Step" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e49-f5d3-e9cd-c200" type="notInstanceOf"/>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1795-c4e8-6ca2-380b" type="notInstanceOf"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Self Only</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="770a-aed5-33c0-2136" name="Quick-Step" hidden="false">
+              <description>Self Only
+A figure may not make a Power Move when attempting to activate this power. The activator may immediately move 4” in any direction, including out of combat. No figure may force combat during this move. The activator may not end this move within 1” of an enemy figure nor exit the table using this move. This move does not suffer any movement penalties for terrain. If the figure fails its activation, it may make a normal Power Move.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="1795-c4e8-6ca2-380b" shared="true" includeChildSelections="false"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8e49-f5d3-e9cd-c200" shared="true" includeChildSelections="false"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="f7a8-0c5f-7f7c-11b4" name="Re-wire Robot" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3451-9646-701f-f6bb" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="0f47-1ab5-f553-a5f3" name="Re-wire Robot" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9d84-3333-57c7-92ea" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">14</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Out of Game (B)</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="2599-bf95-d62e-9c1f" name="Re-wire Robot" hidden="false">
+              <description>Out of Game (B)
+Select one robot in the crew. The robot may be given one of the following enhancements: +1 Move, +1 Fight, +1 Armour; however, it suffers -1 Will. These modifications are permanent. No robot may be re-wired more than once.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="9d84-3333-57c7-92ea" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="9ac1-d653-bb74-af2a" name="Suggestion" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="04a6-d442-0a51-7420" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="51bb-b381-fd8c-c55f" name="Suggestion" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifiers>
+                <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9e36-ac96-3132-f141" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2934-b054-68dc-0468" type="notInstanceOf"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">12</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="9980-9e16-45a0-e6b9" name="Suggestion" hidden="false">
+              <description>Line of Sight
+The target of this power must make an immediate Will Roll (TN16). If it fails, it drops any loot it is carrying, and the activator may move the figure up to 3” in any direction, provided this does not move the figure into combat or cause it any immediate Damage (i.e. falling more than 3”). (Armour Interference).</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="2934-b054-68dc-0468" shared="true" includeChildSelections="false"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="9e36-ac96-3132-f141" shared="true" includeChildSelections="false"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="2da8-9c98-1636-549d" name="Target Designation" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b82-6b82-2be0-6a8a" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="6dbb-5e74-7b4b-7080" name="Target Designation" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1510-fec4-0334-8026" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">8</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="96ff-b060-3cab-e28b" name="Target Designation" hidden="false">
+              <description>Line of Sight
+For the rest of the battle, this figure receives -2 Fight whenever rolling against a Shooting attack.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="1510-fec4-0334-8026" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="6846-1295-8b8c-06a0" name="Target Lock" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef56-8576-0dd3-4534" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="1b20-0bf5-8e87-730f" name="Target Lock" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1795-c4e8-6ca2-380b" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Touch</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="139f-1b76-98a9-c968" name="Target Lock" hidden="false">
+              <description>Touch
+The activator may make an immediate grenade or grenade launcher attack as a free action against any point in range; it does not have to be in line of sight. The attack automatically hits its intended point. If this power is used during a group activation, then the grenade or grenade launcher attack can be made by another member of the crew that is within 1” and was part of the group activation.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="1795-c4e8-6ca2-380b" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="cf28-d05b-2265-bccb" name="Temporary Upgrade" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="65d1-1c54-3848-17af" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="78dd-2a4e-b3c1-b867" name="Temporary Upgrade" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1795-c4e8-6ca2-380b" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">12</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Self Only</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="1c96-d445-8f0f-96dd" name="Temporary Upgrade" hidden="false">
+              <description>Self Only
+The activator may select one of the following stat increases: +1 Move, +1 Fight, +1 Shoot, +3 Will, +1 Armour. These may not take the figure above Move (7), Fight (+6), Shoot (+6), Will (+8), or Armour (14). A figure may only have one upgrade activate a time, but they may use this power again to switch from one upgrade to another.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="1795-c4e8-6ca2-380b" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="ea73-1f02-4fb9-81f3" name="Toxic Claws" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="560a-252a-3b5b-3868" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="24ac-5763-ba2c-8f33" name="Toxic Claws" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6939-3fb3-687a-2a0b" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Self Only</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="b083-b442-178f-2edb" name="Toxic Claws" hidden="false">
+              <description>Self Only
+The figure immediately grows a set of indestructible claws. These count as a hand weapon, do +2 Damage, and are toxic.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="6939-3fb3-687a-2a0b" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="b69f-030a-4ccc-fa10" name="Toxic Secretion" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b627-91a9-c70a-365f" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="cf46-005b-7fe3-aa39" name="Toxic Secretion" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6939-3fb3-687a-2a0b" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">12</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Out of Game (B)</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="6499-c957-3ea0-1b9f" name="Toxic Secretion" hidden="false">
+              <description>Out of Game (B)
+The activator may select up to two members of their crew, including itself. All attacks made by those figures, including Shooting attacks, count as toxic for the next game.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="6939-3fb3-687a-2a0b" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="d9de-4c95-381c-1252" name="Transport" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="93bd-56de-22cd-9b56" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="f542-ef0f-79aa-d0d5" name="Transport" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8702-3db8-4e88-faf8" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="0533-c7dd-ab54-23bc" name="Transport" hidden="false">
+              <description>Line of Sight
+May target one member of the same crew that is within Line of Sight and 12” from the activator. This figure can be moved up to 6” in any direction (maintaining line of sight). If the figure was carrying a loot token, the token is dropped and not moved with the figure.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8702-3db8-4e88-faf8" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="f344-aa43-4cf4-0426" name="Void Blade" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c09b-2f7b-d729-59a0" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="6ab8-0d23-18e8-5d2c" name="Void Blade" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2934-b054-68dc-0468" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Self Only</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="89e3-6078-8c5c-0ad4" name="Void Blade" hidden="false">
+              <description>Self Only
+A figure must be carrying a hand weapon in order to use this power. This hand weapon becomes indestructible and does +2 Damage. In addition, the figure receives +3 Fight whenever they are rolling against a Shooting attack generated by a pistol, carbine, rapid-fire, or shotgun. This bonus does not stack with cover; the player should use whichever modifier is greater. If this figure ever becomes stunned, this power is immediately cancelled. A figure with an active void blade cannot use any weapon that takes up more than 1 gear slot.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="2934-b054-68dc-0468" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="701f-9fc0-751b-c6ae" name="Wall of Force" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d18-e7a7-1406-5c42" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="da7e-7ee5-4774-7826" name="Wall of Force" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9e36-ac96-3132-f141" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">12</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Self Only</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="7097-be64-3284-3c99" name="Wall of Force" hidden="false">
+              <description>Self Only
+Creates an impenetrable, transparent wall, up to 6” long and 3” high anywhere within line of sight of the activator. This wall cannot be climbed (though any point it is anchored on may be). Grenade and grenade launcher attacks may be made over the wall. Figures may make a Shooting action at the wall. In that case, roll a die, on a 19–20, the wall is immediately cancelled.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="9e36-ac96-3132-f141" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="f2f3-e67a-83c3-957f" name="Beast Call" publicationId="460c-b731-33cf-903c" page="14" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8519-ea6a-a595-6b07" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="f648-5a42-475c-ef61" name="Beast Call" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a163-ca0d-f3a8-52fa" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">12</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Touch</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="3134-0fd5-b65e-279e" name="Beast Call" hidden="false">
+              <description>This power has no specific target, instead immediately roll on the Random Encounter table (see Stargrave rulebook, page 140) and place that creature at a randomly determined point on the table edge. The figure that used the power may choose to reroll this randomly determined point, but in this case, the second roll must be accepted. The figure may not use this power again while this creature remains on the table.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ac91-c165-0a8c-a834" name="Crack Shot" publicationId="460c-b731-33cf-903c" page="14" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ccd-7b44-9b00-57e3" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="fdf1-f3d2-b49c-56bf" name="Crack Shot" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a163-ca0d-f3a8-52fa" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Self Only</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="7328-e136-0b2b-bc12" name="Crack Shot" hidden="false">
+              <description>This figure now scores a critical hit on Shooting Attacks on a natural 19 or 20 (though not if the defender also rolls a 20). In addition, this figure never suffers a jam result for rolling a natural 1 on a shooting attack or for any other reason.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="12b1-e4d8-55ac-2393" name="Contacts" publicationId="460c-b731-33cf-903c" page="14" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa46-f05f-2910-5ce3" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="57ea-d717-b870-43c8" name="Contacts" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="bc20-7fbc-9e6d-b851" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">12</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Out of Game  (A)</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="eb05-85fc-22df-414b" name="Contacts" hidden="false">
+              <description>The figure has numerous contacts, especially when looking to buy specific items. The crew may select one item from any Advanced Technology table. The crew may buy this item at any point before the start of their next game.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6072-ed43-ae15-8781" name="Indifference" publicationId="460c-b731-33cf-903c" page="14" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="13fd-b489-d904-5784" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="1aee-f69e-a08e-fb16" name="Indifference" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="bc20-7fbc-9e6d-b851" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">12</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Self-Only</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="7afd-259b-1a63-cab3" name="Indifference" hidden="false">
+              <description>This figure is able to compartmentalize pain and shock so that it doesn&apos;t slow them down. For the rest of the game, this figure never counts as wounded. In addition, whenever the figure suffers damage that would normally stun it, the player may choose whether or not the figure is stunned.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7a20-0a5f-7f0e-2af2" name="Inspiring" publicationId="460c-b731-33cf-903c" page="14" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="21e1-4014-a1bf-6f78" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="1100-7cc5-21fe-6dd6" name="Inspiring" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="bc20-7fbc-9e6d-b851" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">12</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Self-Only</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="713a-dd61-6569-27ed" name="Inspiring" hidden="false">
+              <description>This power may be used in two different ways: either the target figure immediately recovers from being stunned and suffers no penalties for this stunning during their own activation; or the target figure receives +1 Fight for the remainder of the game. A figure may never receive more than +1 Fight from the use of this power.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d1c6-5201-07ad-7536" name="Investments" publicationId="460c-b731-33cf-903c" page="15" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a65c-a40c-66fc-5501" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="335d-3e55-b78d-61ae" name="Investments" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="bc20-7fbc-9e6d-b851" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">12</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Out of Game (A)</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="fd55-a497-0fd8-e335" name="Investments" hidden="false">
+              <description>The figure is a master of making money work. The crew immediately gains 50cr.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="03b7-b900-850b-fb76" name="Study Prey" publicationId="460c-b731-33cf-903c" page="15" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cdb3-fdfe-cca1-5d57" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="e8ed-124f-78fd-1101" name="Study Prey" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a163-ca0d-f3a8-52fa" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">12</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Out of Game (A)</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="096f-2e31-a4b6-53a3" name="Study Prey" hidden="false">
+              <description>If this figure&apos;s crew killed any uncontrolled creatures during the previous game, they receive +5 experience points for each creature, in addition to any experience points normally claimed from the experience point table or from the bonus expereince points for a scenario. A maximum of +25 experience points can be earned in this fashion, even if both the captain and first mate possess this power. These bonus experience points do not count against the 300 expereince point maximum for each game.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8db2-3ddd-99f0-eed9" name="Weapon Maintenance" publicationId="460c-b731-33cf-903c" page="15" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e30-06d3-075c-ebef" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="847c-e82d-251d-170b" name="Weapon Maintenance" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a163-ca0d-f3a8-52fa" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Out of Game (B)</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="e5d5-fbf7-7aec-a4d8" name="Weapon Maintenance" hidden="false">
               <description>Select one carbine, shotgun, or pistol. That weapon becomes indestrctible, gains +1 damage, and never jams (Shooting Rolls of &apos;1&apos; trigger no special effects), for the duration of the next game.</description>
             </rule>
           </rules>

--- a/Stargrave.gst
+++ b/Stargrave.gst
@@ -952,6 +952,13 @@ This figure immediately gains an additional action during this activation, and a
             <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
             <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
           </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden" scope="8f77-0290-5b40-2a4c" affects="self.entries.forces.recursive">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="6939-3fb3-687a-2a0b" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
         </selectionEntry>
         <selectionEntry id="983a-fdc1-e31c-f8b6" name="Antigravity Projection" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -3519,15 +3526,2897 @@ Creates an impenetrable, transparent wall, up to 6” long and 3” high anywher
         </selectionEntryGroup>
       </selectionEntryGroups>
     </selectionEntryGroup>
-    <selectionEntryGroup name="Core Powers" id="8f77-0290-5b40-2a4c" hidden="false">
-      <entryLinks>
-        <entryLink import="true" name="Powers" hidden="false" id="3c58-2a49-656f-f3e1" type="selectionEntryGroup" targetId="7753-4141-f613-ae54"/>
-      </entryLinks>
-    </selectionEntryGroup>
     <selectionEntryGroup name="Other Powers" id="d187-4aa6-4f21-7b77" hidden="false">
       <entryLinks>
         <entryLink import="true" name="Powers" hidden="false" id="791d-dd71-aa6e-63a6" type="selectionEntryGroup" targetId="7753-4141-f613-ae54"/>
       </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="4da1-d546-eaec-5450" name="Core Powers" hidden="false" collective="false" import="true">
+      <selectionEntries>
+        <selectionEntry id="ff98-6c68-7984-3719" name="Adrenaline Surge" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd22-6c16-c0ff-7fc9" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="e85c-e47a-e7bc-51ae" name="Adrenaline Surge" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6939-3fb3-687a-2a0b" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">12</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">2</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Self Only</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="dfe6-8fb0-9538-3f1c" name="Adrenaline Surge" hidden="false">
+              <description>Self Only
+This figure immediately gains an additional action during this activation, and an additional action in their next activation as well.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="6939-3fb3-687a-2a0b" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="adc5-cb64-cc6c-94cd" name="Antigravity Projection" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3329-24c3-b6cc-5666" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="6e53-2dc8-f023-259b" name="Antigravity Projection" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8702-3db8-4e88-faf8" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="da1a-8f8d-da28-276e" name="Antigravity Projection" hidden="false">
+              <description>Line of Sight
+The target figure gains the Levitate attribute (page 156) for the rest of the game.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8702-3db8-4e88-faf8" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="efec-d45b-9df4-7479" name="Armour Plates" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="871c-559f-d2fa-3008" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="e1bf-ab74-1b47-2831" name="Armour Plates" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6939-3fb3-687a-2a0b" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">2</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Self Only or Out of Game (B)</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="c79e-56fc-0f5f-8ece" name="Armour Plates" hidden="false">
+              <description>Self Only or Out of Game (B)
+The figure gains +2 Armour. This power may not be used if the figure is already wearing combat armour.
+This power can be used Out of Game (B), in which case the activating figure starts the game at -2 Damage to represent the Strain.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="6939-3fb3-687a-2a0b" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="1325-c860-73dc-a3bc" name="Armoury" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b886-5d23-b224-de14" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="7fa3-0874-f440-1a15" name="Armoury" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1510-fec4-0334-8026" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Out of Game (B)</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="a65a-658f-3221-8030" name="Armoury" hidden="false">
+              <description>Out of Game (B)
+The crew can field one suit of combat armour without having to pay is normal upkeep cost.
+Alternatively, one standard (not Advanced Technology) pistol, carbine, or shotgun may be given a +1 Damage modifier for the next game only.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="1510-fec4-0334-8026" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="86f3-9552-92af-ad40" name="Bait and Switch" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc54-3159-a4cf-138f" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="111e-f84e-26f3-c637" name="Bait and Switch" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e49-f5d3-e9cd-c200" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">12</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">2</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="2a48-bfaa-59d5-968d" name="Bait and Switch" hidden="false">
+              <description>Line of Sight
+This power may only be used against a soldier carrying a loot token. That figure must make an immediate Will Roll (TN14). If failed, the figure immediately drops the loot token and the  activator may move it up to 4” in any direction.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8e49-f5d3-e9cd-c200" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="9725-f006-6642-a487" name="Break Lock" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb04-6c1c-ea97-0cd9" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="ef4e-05eb-66c6-2340" name="Break Lock" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9e36-ac96-3132-f141" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">12</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="78d2-8781-9ecf-8850" name="Break Lock" hidden="false">
+              <description>Line of Sight
+Immediately unlocks one physical-loot counter.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="9e36-ac96-3132-f141" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="e084-1ec7-ab9e-ec5a" name="Bribe" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="76c0-1deb-6650-0c96" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="ec3b-e654-46a4-dc59" name="Bribe" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e49-f5d3-e9cd-c200" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">14</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Out of Game (B)</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="1abd-fecd-02a7-9471" name="Bribe" hidden="false">
+              <description>Out of Game (B)
+If successful, place one bribe token next to the table and make your opponent aware of it. At any point of the game, when your opponent declares that a soldier (not a captain or first mate) is making a Shooting attack, but before the dice are rolled, you may play your bribe token. The Shooting attack automatically misses, and no dice are rolled. No crew may use more than one bribe token in any game.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8e49-f5d3-e9cd-c200" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="89da-cdc2-ad87-b4bf" name="Camouflage" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="faae-d93a-fb2e-1303" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="b904-907c-fd4c-dc47" name="Camouflage" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1795-c4e8-6ca2-380b" type="notInstanceOf"/>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6939-3fb3-687a-2a0b" type="notInstanceOf"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">2</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Self Only</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="f9fa-9a69-c0b6-01fb" name="Camouflage" hidden="false">
+              <description>Self Only
+No figure may draw line of sight to this figure if it is more than 12” away. In addition, it gains +2 Fight when rolling against Shooting attacks from pistol, carbine, shotgun, or rapid-fire attacks. This power is cancelled if the figure becomes stunned.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="6939-3fb3-687a-2a0b" shared="true"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="1795-c4e8-6ca2-380b" shared="true"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="9d0a-b6d4-cd0d-10cf" name="Cancel Power" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca3b-387e-a662-b473" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="3720-c86a-184b-9e1f" name="Cancel Power" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e49-f5d3-e9cd-c200" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">12</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="62e8-5e11-0c78-cb3a" name="Cancel Power" hidden="false">
+              <description>Line of Sight
+Immediately cancels all effects of one ongoing Line of Sight power. It has no effect on powers with other designations.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8e49-f5d3-e9cd-c200" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="c8be-68ca-8c4d-098d" name="Command" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9614-1d0f-8c9a-cb41" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="1ca6-9328-6516-3e2b" name="Command" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1510-fec4-0334-8026" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="eb6f-ba9c-aaec-a0bb" name="Command" hidden="false">
+              <description>Line of Sight
+Select one member of the crew that is in line of sight. That figure now activates in the current player’s phase this turn. This power may not be used on a figure that has already activated in this turn.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="1510-fec4-0334-8026" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="706d-9a5f-8c50-c1af" name="Concealed Firearm" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf1c-aebf-8c41-4b83" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="e421-a27b-e182-89fc" name="Concealed Firearm" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e49-f5d3-e9cd-c200" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Self Only</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="b424-f90d-ff3b-b3f9" name="Concealed Firearm" hidden="false">
+              <description>Self Only
+This power may only be used while a figure is in combat. The figure may make one +5 Shooting attack against any other figure in the combat. Do not randomize the target of the attack, even if there are multiple figures in the combat. If this attack damages the target, it is automatically pushed back 1” and stunned, even if the attack did less than 4 Damage.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8e49-f5d3-e9cd-c200" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="45c0-d29b-e462-a1be" name="Control Animal" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6848-89f9-f2ff-d170" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="ae9a-51b2-d334-8338" name="Control Animal" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2934-b054-68dc-0468" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="29dc-1a2f-a765-e396" name="Control Animal" hidden="false">
+              <description>Line of Sight
+This power may only be used against uncontrolled animals. The target animal must make an immediate Will Roll (TN16) or become a temporary member of the same crew as the activator. Each figure with this power may only have one animal under control at any time. They may cancel this power at any time as a free action.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="2934-b054-68dc-0468" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="f5c2-3fa4-4831-bccd" name="Control Robot" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="21fa-5026-21e6-c100" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="8299-52dc-4771-96bd" name="Control Robot" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9d84-3333-57c7-92ea" type="notInstanceOf"/>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1795-c4e8-6ca2-380b" type="notInstanceOf"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="3f5d-8f28-9136-370c" name="Control Robot" hidden="false">
+              <description>Line of Sight
+Select one robot in line of sight. That robot must make an immediate Will Roll (TN15). If it succeeds, nothing happens. If it fails, it immediately joins the crew of activator as a temporary member. The controlled robot may make a new Will Roll (TN15) after each of its activations. If it succeeds this power is canceled and the robot immediately reverts to its previous allegiance. A figure with this power may only have one robot under control at any time. They may cancel this power at any time as a free action.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="1795-c4e8-6ca2-380b" shared="true" includeChildSelections="false"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="9d84-3333-57c7-92ea" shared="true" includeChildSelections="false"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="1896-63b8-0fc0-78ba" name="Coordinated Fire" hidden="true" collective="false" import="true" type="upgrade">
+          <comment>Activation: 10 / Strain: 0 / Line of Sight
+The target member of the crew receives +1 Shoot for
+the duration of the game. This may not take a figure
+above +5 Shoot. A figure may only benefit from one
+Coordinated Fire Power at a time.</comment>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c6a-1a62-58ee-8d74" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="4400-8e6b-00e2-a067" name="Coordinated Fire" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1510-fec4-0334-8026" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="9e51-caa6-a8ee-2518" name="Coordinated Fire" hidden="false">
+              <description>Line of Sight
+The target member of the crew receives +1 Shoot for the duration of the game. This may not take a figure above +5 Shoot. A figure may only benefit from one Coordinated Fire Power at a time.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="1510-fec4-0334-8026" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="24d2-af1e-ef47-46bf" name="Create Robot" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91ec-d203-c7f6-894e" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="9831-6e88-2d33-750b" name="Create Robot" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9d84-3333-57c7-92ea" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">14</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Out of Game (A)</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="23a8-6111-d7bb-9318" name="Create Robot" hidden="false">
+              <description>Out of Game (A)
+The player may immediately add one robot soldier to their crew for no cost. This soldier can be of any type except Armoured Trooper, but the crew is still subject to the normal limitation on soldiers and specialist soldiers.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="9d84-3333-57c7-92ea" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="5810-5b5c-a15f-3695" name="Dark Energy" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ef0-b5f8-ddd9-3eb5" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="348c-40f3-4cb6-5f41" name="Dark Energy" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2934-b054-68dc-0468" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="3a00-938a-2232-0a0e" name="Dark Energy" hidden="false">
+              <description>Line of Sight
+The figure makes a +5 Shooting attack against any target within 12”. This attack ignores any armour worn by a figure (so subtract a figure’s armour 1modifier from their armour). Increase this attack to +7 against robots. If this attack targets a figure in combat, do not randomize the target, it can only hit the intended target. (Armour Interference).</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="2934-b054-68dc-0468" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="cd8f-e249-aed4-314d" name="Data Jump" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f933-0c22-07f0-59bd" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="9ea1-5f97-92c7-5f56" name="Data Jump" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8702-3db8-4e88-faf8" type="notInstanceOf"/>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e49-f5d3-e9cd-c200" type="notInstanceOf"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="fa35-ed58-a988-7474" name="Data Jump" hidden="false">
+              <description>Line of Sight
+This power may only target a member of the same warband that is carrying a data-loot token. The player may immediately move the data-loot token carried by that figure to another member of the crew, provided both are in line of sight of the activator and within 8” of one another.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8e49-f5d3-e9cd-c200" shared="true" includeChildSelections="false"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8702-3db8-4e88-faf8" shared="true" includeChildSelections="false"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="e0ef-50b4-7ece-4074" name="Data Knock" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="573d-a6b1-a095-dc99" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="9278-da25-28f9-a181" name="Data Knock" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8702-3db8-4e88-faf8" type="notInstanceOf"/>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1795-c4e8-6ca2-380b" type="notInstanceOf"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">12</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="6ba6-0138-7e1c-2860" name="Data Knock" hidden="false">
+              <description>Line of Sight
+Immediately unlocks one data-loot counter.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="1795-c4e8-6ca2-380b" shared="true" includeChildSelections="false"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8702-3db8-4e88-faf8" shared="true" includeChildSelections="false"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="7796-4916-f512-4b86" name="Data Skip" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2f4-f438-a173-5a48" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="05ee-b081-d9f3-bd63" name="Data Skip" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8702-3db8-4e88-faf8" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">12</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">2</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="c2fc-41f7-125d-7785" name="Data Skip" hidden="false">
+              <description>Line of Sight
+This power targets an unlocked data-loot token or a figure carrying such a token that is within 12”. If the token is not being carried, the activator may move the data-loot token 4” in any direction. If a figure is carrying the token, then that figure must make a Will Roll (TN16). If failed, the activator may move the data-loot token up to 4” in any direction. Either way, the token remains unlocked.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8702-3db8-4e88-faf8" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="c27b-c259-9903-ec2c" name="Destroy Weapon" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e330-e121-5124-118d" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="4e90-d386-698a-03c0" name="Destroy Weapon" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9e36-ac96-3132-f141" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">12</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">2</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="28bf-e9d6-9fdd-aad0" name="Destroy Weapon" hidden="false">
+              <description>Line of Sight
+This power may be used against any figure within 12”. The activator may choose one weapon carried by that figure to be destroyed, except indestructible weapons. This weapon is replaced for free after the game. (Armour Interference).</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="9e36-ac96-3132-f141" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="f7ac-d784-4667-cad6" name="Drone" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b824-aa8b-4e5f-b869" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="72ea-ccf1-1a8b-44ef" name="Drone" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8702-3db8-4e88-faf8" type="notInstanceOf"/>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9d84-3333-57c7-92ea" type="notInstanceOf"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Touch</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="83e6-0c92-6200-8b26" name="Drone" hidden="false">
+              <description>Touch
+Place a drone next to the activator (see Chapter Six: Bestiary, page 144). This drone counts as a temporary member of the crew, and may activate and move as normal. For the rest of the game, the figure may draw line of sight from the drone, instead of the figure, when using a power. This includes using Touch powers. A figure may only have one active drone at a time.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="9d84-3333-57c7-92ea" shared="true" includeChildSelections="false"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8702-3db8-4e88-faf8" shared="true" includeChildSelections="false"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="ae17-aa25-8875-4a3e" name="Electromagnetic Pulse" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d8fc-f81f-4cd5-c6a1" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="e0e6-2b4b-81fa-8ffb" name="Electromagnetic Pulse" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8702-3db8-4e88-faf8" type="notInstanceOf"/>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9d84-3333-57c7-92ea" type="notInstanceOf"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="5b43-20cf-baa7-47e8" name="Electromagnetic Pulse" hidden="false">
+              <description>Line of Sight
+If targeted against a robot, that robot must make an immediate Will Roll (TN18). If it fails, it receives no actions the next time it activates.
+If targeted against a non-robot figure, all firearms carried by that figure immediately jam as though they had rolled a 1 on a Shooting attack. Additionally, the weapon suffers a -1 Damage modifier for the rest of the game. A weapon can be jammed in multiple turns through the use of this power, but the Damage modifier only applies the first time.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="9d84-3333-57c7-92ea" shared="true" includeChildSelections="false"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8702-3db8-4e88-faf8" shared="true" includeChildSelections="false"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="0944-6234-2ab9-9820" name="Energy Shield" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ea8-c5b4-eda6-ece5" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="adf2-6c65-d252-25c8" name="Energy Shield" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1510-fec4-0334-8026" type="notInstanceOf"/>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1795-c4e8-6ca2-380b" type="notInstanceOf"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Self Only</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="9dda-f8ec-b8d7-4dac" name="Energy Shield" hidden="false">
+              <description>Self Only
+A small energy shield forms around the user. This shield absorbs the next 3 points of Damage from any Shooting attack that would injure the activator. Once 3 points of Damage have been absorbed, the power is cancelled.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="1795-c4e8-6ca2-380b" shared="true" includeChildSelections="false"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="1510-fec4-0334-8026" shared="true" includeChildSelections="false"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="70c4-3c95-29e6-a5e7" name="Fling" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="93a7-b8df-af4d-7481" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="6c68-00ba-eea2-70bb" name="Fling" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6939-3fb3-687a-2a0b" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">8</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Self Only or Touch</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="7e68-b33d-bbba-5b42" name="Fling" hidden="false">
+              <description>Self Only or Touch
+This power can be used in two ways. The activator may use it while standing within 1” of a member of their crew, in which case they may immediately move that crewmember 6” in any
+direction, including up. However, the figure that was moved is immediately stunned. Alternatively, it can be used while in combat against a specific enemy figure. The target figure must
+make an immediate Fight Roll (TN16). If it fails, the activator may move the target figure up to 6” in any horizontal direction. The figure takes no Damage (unless there is another reason it would, such as falling), but is stunned. This power may not be used on any figure that has the Large attribute.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="6939-3fb3-687a-2a0b" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="117c-854a-91c3-306f" name="Fortune" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c71-427b-e38f-ad97" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="2363-f190-e20d-8b64" name="Fortune" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1510-fec4-0334-8026" type="notInstanceOf"/>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e49-f5d3-e9cd-c200" type="notInstanceOf"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">12</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Self Only</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="dc89-caf1-e080-79ff" name="Fortune" hidden="false">
+              <description>Self Only
+Place a fortune token either next to the figure or on your crew sheet next to the figure’s entry. At any point the player may discard this token to reroll a Combat Roll, Shooting Roll, or Stat Roll made by that figure. If used, the figure must take the result of the reroll, they cannot choose to take the original roll. No figure may have more than one fortune token at one time.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8e49-f5d3-e9cd-c200" shared="true" includeChildSelections="false"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="1510-fec4-0334-8026" shared="true" includeChildSelections="false"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="21a6-a836-bcb2-0c73" name="Haggle" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ae7-9ec4-b879-9f42" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="2d2c-79a1-1ddc-2ed7" name="Haggle" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e49-f5d3-e9cd-c200" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Out of Game (A)</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="b46e-8cd7-0340-3ebd" name="Haggle" hidden="false">
+              <description>Out of Game (A)
+This power may be used whenever the crew sells anything. The crew receives 20% more than the usual selling price. This power may only be used on the sale of one item after each game.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8e49-f5d3-e9cd-c200" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="46fb-5320-b630-6284" name="Heal" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b2d3-58c2-b8e3-4d13" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="9f91-b1f1-63a8-8e1a" name="Heal" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2934-b054-68dc-0468" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="2017-1d87-ecc3-477d" name="Heal" hidden="false">
+              <description>Line of Sight
+This power restores up to 5 points of lost Health to a target figure within 6”. This power cannot take a figure above its starting Health. This power has no effect on robots. (Armour  Interference).</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="2934-b054-68dc-0468" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="c8d8-1650-de56-3aae" name="Holographic Wall" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="332a-7707-7f72-1949" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="bf36-31eb-283a-2187" name="Holographic Wall" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8702-3db8-4e88-faf8" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="6611-48fb-1ce3-a212" name="Holographic Wall" hidden="false">
+              <description>Line of Sight
+Creates a holographic wall 6” long and 3” high. No line of sight may be drawn through this wall. Figures may move through the wall as though it is not there. At the end of each turn, after the turn in which the wall is placed, roll a die. On a 1–4 the holograph fails, and the wall is removed.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8702-3db8-4e88-faf8" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="947c-e843-59f1-4fd3" name="Life Leach" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f957-064d-e452-31a5" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="47f6-a637-68b0-b8d5" name="Life Leach" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2934-b054-68dc-0468" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="63b1-4d40-ceed-50a5" name="Life Leach" hidden="false">
+              <description>Line of Sight
+The target must make an immediately Will Roll (TN15). If failed the target loses 3 Health and the figure using the power regains 3 Health. This may not take a figure above its starting Health. This power cannot be used against robots. A figure may use this power on a member of their own crew, but if so, that figure is immediately removed from the crew sheet
+and counts as an uncontrolled figure for the rest of the game. (Armour Interference).</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="2934-b054-68dc-0468" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="18fd-a7f7-b805-7a9c" name="Lift" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4057-878a-acbb-a799" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="44bc-ed52-b91d-4eec" name="Lift" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9e36-ac96-3132-f141" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="b39d-5feb-5c96-c9eb" name="Lift" hidden="false">
+              <description>Line of Sight
+Immediately move one member of the same crew that is in line of sight 6” in any direction, including vertically. If this leaves the figure hanging above the ground, it immediately drops to the ground, but takes no Damage. The figure that is moved cannot take any additional actions this turn, though may have taken actions previously this turn. This may not move a figure off the table. (Armour Interference).</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="9e36-ac96-3132-f141" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="faa2-7887-ee29-bb50" name="Mystic Trance" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf40-e81b-041e-0e32" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="2b6f-4ed5-0ade-cfd3" name="Mystic Trance" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2934-b054-68dc-0468" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">8</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Out of Game (B)</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="82da-4d28-b719-527c" name="Mystic Trance" hidden="false">
+              <description>Out of Game (B)
+If successfully activated, the figure may attempt to use one of their other powers before the first Initiative Roll as if it was an Out of Game (B) power. No power that targets a point on the table or an enemy figure can be used with Mystic Trance.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="2934-b054-68dc-0468" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="d42d-d3a9-0c85-2416" name="Power Spike" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ad0-ffc7-4393-d0b1" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="7a3a-973a-f949-5007" name="Power Spike" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1510-fec4-0334-8026" type="notInstanceOf"/>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1795-c4e8-6ca2-380b" type="notInstanceOf"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">8</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Self Only</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="8458-a244-262c-7acd" name="Power Spike" hidden="false">
+              <description>Self Only
+The next time this figure makes a Shooting attack with a carbine, pistol, or shotgun, the shot does +3 Damage. This is cumulative with other damage modifiers for the weapon. For example, the total modifier would +4 in the case of a shotgun (+3 from Power Spike and +1 from the Shotgun).</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="1795-c4e8-6ca2-380b" shared="true" includeChildSelections="false"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="1510-fec4-0334-8026" shared="true" includeChildSelections="false"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="91c7-fb81-6ce7-713c" name="Psionic Fire" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="153f-48c1-176a-95ef" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="e135-1ef8-a42d-5d60" name="Psionic Fire" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9e36-ac96-3132-f141" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Self Only</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="ecfa-c350-836e-6926" name="Psionic Fire" hidden="false">
+              <description>Self Only
+The activator should place two flamethrower templates as thought the figure had just made a flamethrower attack. These templates may be touching, but may not overlap. Every figure touching a template immediately suffers a +3 flamethrower attack (see page 32). Figures only suffer one attack even if touching both templates. (Armour Interference).</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="9e36-ac96-3132-f141" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="7eb9-c2ff-3d3a-bc91" name="Pull" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a73-370b-84ee-de37" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="fa75-77d0-8ad0-8894" name="Pull" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9e36-ac96-3132-f141" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">12</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="c645-a626-2040-e60f" name="Pull" hidden="false">
+              <description>Line of Sight
+The target figure must make a Will Roll (TN16). If it fails, move that figure up to 6” in any horizontal direction. This may not move a figure over terrain more than 0.5” high. If this moves them off terrain that is above the ground, they fall and take Damage as normal. (Armour Interference).</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="9e36-ac96-3132-f141" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="24dd-467e-3f20-e66a" name="Puppet Master" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bdd2-5c08-9911-6dab" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="73fb-8198-12a6-d3d5" name="Puppet Master" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2934-b054-68dc-0468" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">12</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">2</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Touch</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="5125-b7f9-b6bd-57d7" name="Puppet Master" hidden="false">
+              <description>Touch
+Choose one non-robot member of the crew that has been reduced to 0 Health during the game. That soldier returns to the table, adjacent to the figure activating this power. The soldier has 1 Health and counts as wounded. They are treated as a normal soldier in every other way. Any given soldier may only be returned to the table once each game through the use of Puppet Master. (Armour Interference).</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="2934-b054-68dc-0468" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="46e7-c66c-34bf-65e7" name="Psychic Shield" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7964-5443-4370-2fff" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="ab86-6afa-0d93-f1c7" name="Psychic Shield" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9e36-ac96-3132-f141" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">2</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="77f1-7777-4015-150b" name="Psychic Shield" hidden="false">
+              <description>Line of Sight
+The target figure is surrounded by psychic energy. The next time it is hit with a Shooting attack that causes Damage of any amount, halve that Damage (rounding down), and then the power is cancelled. It this figure is ever in combat, this power is immediately cancelled. If the figure also has an active Energy Shield, deduct then 3 points of Damage for it first, then halve the remaining for the Psychic Shield. (Armour Interference).</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="9e36-ac96-3132-f141" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="edba-1070-0163-272e" name="Regenerate" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="203c-d4b1-61ed-c984" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="a34d-4399-bd5c-6f06" name="Regenerate" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6939-3fb3-687a-2a0b" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">8</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Self Only</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="c1b4-fdcb-b1de-b9a6" name="Regenerate" hidden="false">
+              <description>Self Only
+The activator regains up to 3 points of lost Health.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="6939-3fb3-687a-2a0b" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="aaff-54b8-585c-fd9f" name="Remote Guidance" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8c31-ed59-5b9d-7032" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="4aea-cd6b-5caa-f603" name="Remote Guidance" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9d84-3333-57c7-92ea" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Out of Game (B) or Touch</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="1a37-d598-c8c4-9a9f" name="Remote Guidance" hidden="false">
+              <description>Out of Game (B) or Touch
+This power may be used on any robot soldier. That robot can always activate in the same phase as the activator, even if it is not within 3”. The player is still limited to a maximum of three soldiers activating in either the Captain or First Mate Phase. An activator may only use Remote Guidance on one robot at a time.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="9d84-3333-57c7-92ea" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="2363-df6c-e5d4-402e" name="Remote Firing" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa55-9155-566b-98da" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="8d4b-e2aa-ede7-b727" name="Remote Firing" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1510-fec4-0334-8026" type="notInstanceOf"/>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9d84-3333-57c7-92ea" type="notInstanceOf"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="25ed-cd01-ea83-df7a" name="Remote Firing" hidden="false">
+              <description>Line of Sight
+This power allows the user to select one robot in the same crew that is within line of sight. That robot makes an immediate +3 Shooting attack against any legal target within 12”. This attack does not count as the robot’s activation, nor does it cost the robot an action.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="9d84-3333-57c7-92ea" shared="true" includeChildSelections="false"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="1510-fec4-0334-8026" shared="true" includeChildSelections="false"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="6b3c-cc86-cd30-9641" name="Repair Robot" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5fb4-adfa-5985-fb82" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="12f3-cf35-eb0a-057d" name="Repair Robot" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9d84-3333-57c7-92ea" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="2c4a-d1d6-bf20-ea12" name="Repair Robot" hidden="false">
+              <description>Line of Sight
+This power restores up to 5 points of lost Health to a target robot within 6”. This power cannot take a figure above its starting Health.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="9d84-3333-57c7-92ea" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="56c6-fd4f-d644-288f" name="Restructure Body" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9509-c5f1-20b3-018b" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="1504-7dc6-138c-8371" name="Restructure Body" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6939-3fb3-687a-2a0b" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Self Only or Out of Game (B)</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="9443-0920-8d6b-e329" name="Restructure Body" hidden="false">
+              <description>Self Only or Out of Game (B)
+The activator gains one of the following traits of its choice: Amphibious, Burrowing, Expert Climber, Immune to Critical Hits, Immune to Toxins, or Never Wounded. It may only gain one of these traits at a time, but can change the attribute from one to another with an additional use of the power.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="6939-3fb3-687a-2a0b" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="4f56-dc40-275c-0678" name="Quick-Step" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6101-1c69-35b2-00e4" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="ccb8-781b-4108-556d" name="Quick-Step" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e49-f5d3-e9cd-c200" type="notInstanceOf"/>
+                            <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1795-c4e8-6ca2-380b" type="notInstanceOf"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Self Only</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="28fc-de40-fdfe-25c5" name="Quick-Step" hidden="false">
+              <description>Self Only
+A figure may not make a Power Move when attempting to activate this power. The activator may immediately move 4” in any direction, including out of combat. No figure may force combat during this move. The activator may not end this move within 1” of an enemy figure nor exit the table using this move. This move does not suffer any movement penalties for terrain. If the figure fails its activation, it may make a normal Power Move.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="1795-c4e8-6ca2-380b" shared="true" includeChildSelections="false"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8e49-f5d3-e9cd-c200" shared="true" includeChildSelections="false"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="fd32-6ece-d750-5575" name="Re-wire Robot" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a99-5c33-67e8-f769" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="aecc-be2d-6fa2-d72b" name="Re-wire Robot" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9d84-3333-57c7-92ea" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">14</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Out of Game (B)</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="8ec6-86f8-b305-6218" name="Re-wire Robot" hidden="false">
+              <description>Out of Game (B)
+Select one robot in the crew. The robot may be given one of the following enhancements: +1 Move, +1 Fight, +1 Armour; however, it suffers -1 Will. These modifications are permanent. No robot may be re-wired more than once.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="9d84-3333-57c7-92ea" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="3321-4046-4750-2b52" name="Suggestion" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1754-6412-affb-58d1" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="ff1a-f75b-9764-60c8" name="Suggestion" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifiers>
+                <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9e36-ac96-3132-f141" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2934-b054-68dc-0468" type="notInstanceOf"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">12</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="4644-7feb-dece-6620" name="Suggestion" hidden="false">
+              <description>Line of Sight
+The target of this power must make an immediate Will Roll (TN16). If it fails, it drops any loot it is carrying, and the activator may move the figure up to 3” in any direction, provided this does not move the figure into combat or cause it any immediate Damage (i.e. falling more than 3”). (Armour Interference).</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="2934-b054-68dc-0468" shared="true" includeChildSelections="false"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="9e36-ac96-3132-f141" shared="true" includeChildSelections="false"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="7188-b931-2eb2-b23a" name="Target Designation" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b67-d789-9a9e-6567" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="bc17-dac8-0a77-e615" name="Target Designation" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1510-fec4-0334-8026" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">8</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="ef4c-3da9-0857-6b4e" name="Target Designation" hidden="false">
+              <description>Line of Sight
+For the rest of the battle, this figure receives -2 Fight whenever rolling against a Shooting attack.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="1510-fec4-0334-8026" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="5a9b-52ed-f6cd-b4b9" name="Target Lock" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d48-a676-fdb4-06f1" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="becb-ee1d-52c8-ddf4" name="Target Lock" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1795-c4e8-6ca2-380b" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Touch</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="0c06-7f69-a82b-f891" name="Target Lock" hidden="false">
+              <description>Touch
+The activator may make an immediate grenade or grenade launcher attack as a free action against any point in range; it does not have to be in line of sight. The attack automatically hits its intended point. If this power is used during a group activation, then the grenade or grenade launcher attack can be made by another member of the crew that is within 1” and was part of the group activation.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="1795-c4e8-6ca2-380b" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="3ba8-f763-1ef6-b04b" name="Temporary Upgrade" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8bb6-11f2-5e2a-d67b" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="d7ec-97f9-639d-464f" name="Temporary Upgrade" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1795-c4e8-6ca2-380b" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">12</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Self Only</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="8f86-270b-aa15-a79c" name="Temporary Upgrade" hidden="false">
+              <description>Self Only
+The activator may select one of the following stat increases: +1 Move, +1 Fight, +1 Shoot, +3 Will, +1 Armour. These may not take the figure above Move (7), Fight (+6), Shoot (+6), Will (+8), or Armour (14). A figure may only have one upgrade activate a time, but they may use this power again to switch from one upgrade to another.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="1795-c4e8-6ca2-380b" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="7ab5-631f-fc46-da15" name="Toxic Claws" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8067-b351-6a6b-6afa" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="d285-a670-f2c9-f9fe" name="Toxic Claws" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6939-3fb3-687a-2a0b" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Self Only</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="a0fe-2cdb-58ed-fb51" name="Toxic Claws" hidden="false">
+              <description>Self Only
+The figure immediately grows a set of indestructible claws. These count as a hand weapon, do +2 Damage, and are toxic.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="6939-3fb3-687a-2a0b" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="2e06-a01e-617d-9114" name="Toxic Secretion" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a7a-1c95-22ee-e0c7" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="4059-06ef-8dcb-63a7" name="Toxic Secretion" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6939-3fb3-687a-2a0b" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">12</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Out of Game (B)</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="5d28-b749-3b73-d0dc" name="Toxic Secretion" hidden="false">
+              <description>Out of Game (B)
+The activator may select up to two members of their crew, including itself. All attacks made by those figures, including Shooting attacks, count as toxic for the next game.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="6939-3fb3-687a-2a0b" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="a9b9-27e6-b778-e4f8" name="Transport" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb2f-c6f9-3813-a753" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="7af1-1904-46e8-93d9" name="Transport" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8702-3db8-4e88-faf8" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Line of Sight</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="8662-dccb-a6f5-1671" name="Transport" hidden="false">
+              <description>Line of Sight
+May target one member of the same crew that is within Line of Sight and 12” from the activator. This figure can be moved up to 6” in any direction (maintaining line of sight). If the figure was carrying a loot token, the token is dropped and not moved with the figure.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8702-3db8-4e88-faf8" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="f2a0-6141-9da0-ab42" name="Void Blade" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e6f9-5400-3961-30ec" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="ca10-5460-8a9d-69d7" name="Void Blade" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2934-b054-68dc-0468" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Self Only</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="a1a4-0b28-b750-3b63" name="Void Blade" hidden="false">
+              <description>Self Only
+A figure must be carrying a hand weapon in order to use this power. This hand weapon becomes indestructible and does +2 Damage. In addition, the figure receives +3 Fight whenever they are rolling against a Shooting attack generated by a pistol, carbine, rapid-fire, or shotgun. This bonus does not stack with cover; the player should use whichever modifier is greater. If this figure ever becomes stunned, this power is immediately cancelled. A figure with an active void blade cannot use any weapon that takes up more than 1 gear slot.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="2934-b054-68dc-0468" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="16de-bac1-0856-c3a7" name="Wall of Force" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="69c4-1ba3-2d7c-156f" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="a23d-22ff-61ba-6771" name="Wall of Force" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9e36-ac96-3132-f141" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">12</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Self Only</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="8fa1-bce8-9095-2919" name="Wall of Force" hidden="false">
+              <description>Self Only
+Creates an impenetrable, transparent wall, up to 6” long and 3” high anywhere within line of sight of the activator. This wall cannot be climbed (though any point it is anchored on may be). Grenade and grenade launcher attacks may be made over the wall. Figures may make a Shooting action at the wall. In that case, roll a die, on a 19–20, the wall is immediately cancelled.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="9e36-ac96-3132-f141" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry id="7976-8d72-a8fe-5900" name="Beast Call" publicationId="460c-b731-33cf-903c" page="14" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4100-6cf1-a853-cf4c" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="ab10-b27f-5682-5993" name="Beast Call" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a163-ca0d-f3a8-52fa" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">12</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Touch</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="438b-779b-d896-4810" name="Beast Call" hidden="false">
+              <description>This power has no specific target, instead immediately roll on the Random Encounter table (see Stargrave rulebook, page 140) and place that creature at a randomly determined point on the table edge. The figure that used the power may choose to reroll this randomly determined point, but in this case, the second roll must be accepted. The figure may not use this power again while this creature remains on the table.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d751-1414-48bf-f5b2" name="Crack Shot" publicationId="460c-b731-33cf-903c" page="14" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="172d-bd40-5e2a-26d7" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="67c2-e73e-aafb-cd60" name="Crack Shot" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a163-ca0d-f3a8-52fa" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Self Only</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="4aad-ff70-25b7-a1d6" name="Crack Shot" hidden="false">
+              <description>This figure now scores a critical hit on Shooting Attacks on a natural 19 or 20 (though not if the defender also rolls a 20). In addition, this figure never suffers a jam result for rolling a natural 1 on a shooting attack or for any other reason.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e61b-680c-7119-52e4" name="Contacts" publicationId="460c-b731-33cf-903c" page="14" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b35f-cc10-f4e7-5772" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="fe39-cd21-832a-b63c" name="Contacts" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="bc20-7fbc-9e6d-b851" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">12</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Out of Game  (A)</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="388d-7b7b-b393-06f5" name="Contacts" hidden="false">
+              <description>The figure has numerous contacts, especially when looking to buy specific items. The crew may select one item from any Advanced Technology table. The crew may buy this item at any point before the start of their next game.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6853-ea92-7a2c-9354" name="Indifference" publicationId="460c-b731-33cf-903c" page="14" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0596-eff6-66c0-c152" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="4492-8574-8743-845a" name="Indifference" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="bc20-7fbc-9e6d-b851" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">12</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Self-Only</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="b144-f5a6-1b06-017c" name="Indifference" hidden="false">
+              <description>This figure is able to compartmentalize pain and shock so that it doesn&apos;t slow them down. For the rest of the game, this figure never counts as wounded. In addition, whenever the figure suffers damage that would normally stun it, the player may choose whether or not the figure is stunned.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0338-e3ce-d20c-aa6d" name="Inspiring" publicationId="460c-b731-33cf-903c" page="14" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ffd0-4031-992a-a7fa" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="4f08-7c90-e888-2108" name="Inspiring" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="bc20-7fbc-9e6d-b851" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">12</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">1</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Self-Only</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="1db0-5be0-5abd-4382" name="Inspiring" hidden="false">
+              <description>This power may be used in two different ways: either the target figure immediately recovers from being stunned and suffers no penalties for this stunning during their own activation; or the target figure receives +1 Fight for the remainder of the game. A figure may never receive more than +1 Fight from the use of this power.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="54b7-2813-8a00-151e" name="Investments" publicationId="460c-b731-33cf-903c" page="15" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2975-31de-1442-e960" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="75d0-72cb-2b02-7e3f" name="Investments" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="bc20-7fbc-9e6d-b851" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">12</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Out of Game (A)</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="a648-7730-55da-feba" name="Investments" hidden="false">
+              <description>The figure is a master of making money work. The crew immediately gains 50cr.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="9e7d-1a89-b73d-de0f" name="Study Prey" publicationId="460c-b731-33cf-903c" page="15" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="acf7-c9c5-7e94-a9a5" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="b54e-f942-aade-372d" name="Study Prey" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a163-ca0d-f3a8-52fa" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">12</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Out of Game (A)</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="e0ba-9836-f3cb-3781" name="Study Prey" hidden="false">
+              <description>If this figure&apos;s crew killed any uncontrolled creatures during the previous game, they receive +5 experience points for each creature, in addition to any experience points normally claimed from the experience point table or from the bonus expereince points for a scenario. A maximum of +25 experience points can be earned in this fashion, even if both the captain and first mate possess this power. These bonus experience points do not count against the 300 expereince point maximum for each game.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b428-e6f8-1281-3b11" name="Weapon Maintenance" publicationId="460c-b731-33cf-903c" page="15" hidden="true" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b6e-33ba-c1e7-6a0d" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="2412-8ea8-20f2-e7ce" name="Weapon Maintenance" hidden="false" typeId="a2e0-41b3-dd72-62cd" typeName="Power">
+              <modifierGroups>
+                <modifierGroup>
+                  <modifiers>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8749-37ea-6f9e-0824" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="1f90-ce6b-c67a-92fd" value="2">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a163-ca0d-f3a8-52fa" type="notInstanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </modifierGroup>
+              </modifierGroups>
+              <characteristics>
+                <characteristic name="Activation" typeId="1f90-ce6b-c67a-92fd">10</characteristic>
+                <characteristic name="Strain" typeId="c696-f8c0-ecd7-2a79">0</characteristic>
+                <characteristic name="Note" typeId="7838-c665-ec7e-a018">Out of Game (B)</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="0c42-716d-91c6-527f" name="Weapon Maintenance" hidden="false">
+              <description>Select one carbine, shotgun, or pistol. That weapon becomes indestrctible, gains +1 damage, and never jams (Shooting Rolls of &apos;1&apos; trigger no special effects), for the duration of the next game.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Gear Slot" typeId="ef24-ff59-caa4-b0e8" value="0"/>
+            <cost name="Cr" typeId="97c0-4241-980e-66e8" value="0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>


### PR DESCRIPTION
- The user interface now has a group "Powers" containing "Core Powers" and "Other Powers". These lists are populated based on the list of core powers in the base game rule book.
- The number of core powers as well as the total number of powers have been limited for captains and first mates according to the rule book.
- To do this, I created two copies of the Powers list. Ideally they should be linked and not copies since it will make maintenance easier, but I could not find a way to modify the lists without impacting the original list.
- I have not covered anything outside the base game since I do not have those rule books, e.g., Hunter. Those powers will all be found in the Other Powers list, so it should not break the game for those classes.